### PR TITLE
Fix startup crash + 6 high-impact bugs from a full-codebase audit

### DIFF
--- a/chat_window.py
+++ b/chat_window.py
@@ -1180,6 +1180,13 @@ class ChatWindow(QWidget):
         self._load_messages()
 
     def _new_conversation(self):
+        if self._worker and self._worker.isRunning():
+            return
+        self._stream_flush_timer.stop()
+        self._stream_buffer = ""
+        self._visible_stream_text = ""
+        self._reasoning_stream_text = ""
+        self._current_bubble = None
         self._clear_message_widgets()
         self._conv_id = None
 

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,4 +1,6 @@
 import json
+import os
+import tempfile
 from pathlib import Path
 from process_utils import app_base_dir
 
@@ -54,8 +56,27 @@ class ConfigManager:
                 pass
 
     def save(self):
-        with open(self._path, "w", encoding="utf-8") as f:
-            json.dump(self._data, f, indent=2, ensure_ascii=False)
+        # Atomic write: write to a temp file in the same directory, fsync,
+        # then os.replace into place. Avoids losing all settings (including
+        # llm_api_key) if the process is killed mid-write.
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=self._path.name + ".",
+            suffix=".tmp",
+            dir=str(self._path.parent),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, indent=2, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self._path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def get(self, key, default=None):
         return self._data.get(key, default)

--- a/live2d_widget.py
+++ b/live2d_widget.py
@@ -19,7 +19,15 @@ def _get_display_refresh():
 
 
 class Live2DWidget(QOpenGLWidget):
-    def __init__(self, parent=None):
+    @staticmethod
+    def configure_default_surface_format():
+        """Apply the OpenGL surface format Live2D requires.
+
+        Must be called before QApplication is constructed so the global shared
+        GL context (created when AA_ShareOpenGLContexts is set) gets the
+        correct alpha/stencil buffers. Otherwise shader linking can fail with
+        GL_INVALID_OPERATION on glGetAttribLocation.
+        """
         fmt = QSurfaceFormat()
         fmt.setAlphaBufferSize(8)
         fmt.setSamples(4)
@@ -28,6 +36,7 @@ class Live2DWidget(QOpenGLWidget):
         fmt.setSwapInterval(0)
         QSurfaceFormat.setDefaultFormat(fmt)
 
+    def __init__(self, parent=None):
         super().__init__(parent)
         self._model = None
         self._live2d = None

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from qfluentwidgets import setTheme, Theme
 
 import live2d.v2 as live2d
 from platform_patch import PatchedPlatformManager
+from live2d_widget import Live2DWidget
 from model_manager import ModelManager
 from config_manager import ConfigManager
 from i18n_manager import set_language, detect_system_language
@@ -39,6 +40,7 @@ def main():
 
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_UseDesktopOpenGL)
+    Live2DWidget.configure_default_surface_format()
 
     app = QApplication(sys.argv)
     app.setApplicationName("BandoriPet")

--- a/pet_process.py
+++ b/pet_process.py
@@ -17,6 +17,7 @@ from qfluentwidgets import Theme, setTheme
 import live2d.v2 as live2d
 from config_manager import ConfigManager
 from i18n_manager import current_language, detect_system_language, set_language
+from live2d_widget import Live2DWidget
 from model_manager import ModelManager
 from pet_window import PetWindow
 from platform_patch import PatchedPlatformManager
@@ -52,6 +53,7 @@ def main():
 
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_UseDesktopOpenGL)
+    Live2DWidget.configure_default_surface_format()
     app = QApplication(sys.argv)
     app.setApplicationName(f"BandoriPet-{args.character}")
     app.setOrganizationName("BandoriPet")

--- a/pet_window.py
+++ b/pet_window.py
@@ -230,6 +230,9 @@ class PetWindow(QWidget):
 
     def closeEvent(self, event):
         self._save_config()
+        app = QApplication.instance()
+        if app is not None:
+            app.removeEventFilter(self)
         super().closeEvent(event)
 
     def _schedule_position_save(self):

--- a/pixel_pet_widget.py
+++ b/pixel_pet_widget.py
@@ -124,7 +124,7 @@ class PixelPetWidget(QWidget):
     def _restart_anim_timer(self):
         anim = self._frames.get(self._animation, {})
         fps = max(1, int(anim.get("fps", 8) or 8))
-        self._anim_timer.start(max(1, int(1000 / fps) * 3))
+        self._anim_timer.start(max(1, int(1000 / fps)))
 
     def _advance_frame(self):
         anim = self._frames.get(self._animation, {})

--- a/radial_menu.py
+++ b/radial_menu.py
@@ -217,13 +217,13 @@ class RadialMenu(QWidget):
         if self._is_showing:
             return
 
-        self._center = center
-        self._is_showing = True
-        self._set_center_reveal_value(0.0)
-
         n = len(self._items)
         if n == 0:
             return
+
+        self._center = center
+        self._is_showing = True
+        self._set_center_reveal_value(0.0)
 
         total_w = self._radius * 2 + 80 * 2
         total_h = self._radius * 2 + 80 * 2

--- a/settings_window.py
+++ b/settings_window.py
@@ -731,6 +731,9 @@ class SettingsWindow(QWidget):
         else:
             self._save_llm_config()
         self._cleanup_workers()
+        app = QApplication.instance()
+        if app is not None:
+            app.removeEventFilter(self)
         super().closeEvent(event)
 
     def eventFilter(self, watched, event):


### PR DESCRIPTION
# Fix startup crash + 6 high-impact bugs from a full-codebase audit

## 概要 / Summary

本 PR 包含 7 处修复，均来自一次完整代码审计。第一处是阻断性启动崩溃，其余 6 处覆盖 use-after-free、配置数据丢失、动画速率错误、UI 死锁等真实可触发的问题。每个改动都尽量保持小而局部。

This PR contains 7 fixes from a full-codebase audit. The first is a blocking startup crash; the other six cover real, reproducible bugs: use-after-free on close, config data loss on power loss, wrong animation rate, and a UI deadlock. Each change is intentionally small and local.

---

## 1. [Critical] OpenGL surface format must be set before `QApplication`

**Symptom**

启动时立即崩溃：
OpenGL.error.GLError(
err = 1282, # GL_INVALID_OPERATION
description = b'\xce\xde\xd0\xa7\xb2\xd9\xd7\xf7', # "无效操作"
baseOperation = glGetAttribLocation,
cArguments = (1, b'a_position\x00'),
result = -1,
)

**Root cause**
`QSurfaceFormat.setDefaultFormat(...)` was called inside `Live2DWidget.__init__()`, which runs *after* `QApplication(sys.argv)`. With `Qt::AA_ShareOpenGLContexts` enabled, the global shared GL context is created at `QApplication` startup using whatever default format is set at that moment — i.e. without alpha / stencil buffers. Live2D's shader program is then compiled against this incomplete shared context, linking fails silently, and the subsequent `glGetAttribLocation("a_position")` raises `GL_INVALID_OPERATION`.
Per Qt docs:
> When setting `Qt::AA_ShareOpenGLContexts`, it is strongly recommended to place the call to `setDefaultFormat()` before the construction of the `QGuiApplication`.
**Fix**
Extract the format setup into `Live2DWidget.configure_default_surface_format()` (a `@staticmethod`) and call it from both `main.py` and `pet_process.py` *before* `QApplication(sys.argv)`.
**Files**: `live2d_widget.py`, `main.py`, `pet_process.py`
---
## 2. [Critical] Use-after-free on chat window when starting a new conversation mid-stream
**Repro**
1. 发送一条消息，等 LLM 开始流式返回
2. 流式回复进行中，点击聊天窗口标题栏的 "+ 新会话"
3. 立即崩溃 / 段错误
**Root cause**
`_new_conversation()` 直接调用 `_clear_message_widgets()` 把 `_current_bubble` `deleteLater()`，但**没有检查** `LLMStreamWorker` 是否还在运行。worker 仍会 emit `chunk_received` → `_on_chunk_received` → `_current_bubble.set_text(...)`，此时底层 C++ 对象已销毁。
`_switch_conversation` 和 `_delete_conversation` 都已有 `if self._worker and self._worker.isRunning(): return` 守卫，独 `_new_conversation` 漏了。
**Fix**
Add the same guard. Also stop the stream flush timer and clear stream state to keep the function consistent with `_switch_conversation`.
**File**: `chat_window.py`
---
## 3. [Critical] `installEventFilter` never removed on `closeEvent`
**Symptom**
X 按钮关闭桌宠 / 设置窗口后，下一次任意全局事件可能触发崩溃（use-after-free on the destroyed Qt window）。
**Root cause**
`PetWindow.__init__` 和 `SettingsWindow.__init__` 都调了 `QApplication.instance().installEventFilter(self)`：
- `PetWindow` 只在 `_quit()` 内 `removeEventFilter`，但 `closeEvent`（X 按钮 / `aboutToQuit`）并不走 `_quit`
- `SettingsWindow` **全程没有任何** `removeEventFilter` 调用
事件过滤器仍指向已销毁的 widget，下一次 Qt 派发全局事件时即触发。
**Fix**
在两个 `closeEvent` 里都补上 `app.removeEventFilter(self)`。Qt 对未注册的过滤器移除是幂等的，所以与 `_quit` 内已有的 remove 共存安全。
**Files**: `pet_window.py`, `settings_window.py`
---
## 4. [Critical] `config.json` write is non-atomic — every saved setting can be lost
**Repro**
1. 配置好 LLM API key、模型、角色等
2. 在保存瞬间强杀进程 / 系统断电（任务管理器结束进程也可复现）
3. 重启后 `config.json` 变成 0 字节或被截断
**Impact chain**
`load()` 在 `JSONDecodeError` 分支静默 `pass`，回退到 `DEFAULTS` —— **API key、模型选择、窗口位置、所有用户设置全部清空**。
**Fix**
`save()` 改为：写到同目录下的临时文件 → `flush()` + `os.fsync()` → `os.replace()` 原子重命名。失败路径清理临时文件。
**File**: `config_manager.py`
---
## 5. [Medium] Pixel pet animation runs at 1/3 of configured fps
**Repro**
`frames.json` 里设 `fps: 8` 的动画，实际播放速度只有 ≈2.7 fps。
**Root cause**
```python
self._anim_timer.start(max(1, int(1000 / fps) * 3))   # ← 多余的 *3
疑似遗留调试代码。

Fix

删除 * 3。

File: pixel_pet_widget.py

6. [Medium] Radial menu permanently broken if first show_at happens with empty items
Repro

在 _items 还为空时调用一次 show_at()（例如某个上下文菜单条件分支下没有可用项）
之后哪怕给菜单添加了 items 再 show_at，菜单也永远不再出现
Root cause

def show_at(self, center):
    if self._is_showing:
        return
    self._center = center
    self._is_showing = True              # ← 已设为 True
    self._set_center_reveal_value(0.0)
    n = len(self._items)
    if n == 0:
        return                            # ← 直接 return，永远不会走到 dismiss/复位
_is_showing 一旦置位且没有走完正常显示→关闭流程，就再也不会被复位，后续所有 show_at 全部被 if self._is_showing: return 短路。

Fix

把 "n == 0 return" 提前到设置标志位之前。

File: radial_menu.py

Test plan
not done
python main.py 启动不再触发 glGetAttribLocation GL_INVALID_OPERATION，Live2D 模型正常渲染
not done
流式回复中点击 "+ 新会话"：UI 静默忽略，无崩溃；流式结束后再点 OK
not done
流式回复进行中关窗：无 use-after-free 崩溃
not done
任务管理器强杀进程模拟断电；重启后 config.json 内容完整，API key / 模型选择仍在
not done
像素宠物动画速度恢复到与 frames.json 配置的 fps 一致
not done
径向菜单首次以空 items 触发 show_at 后，再次注册 items 并 show_at 应能正常弹出
Risk / Compatibility
所有改动都是局部修复，未改任何接口、文件格式、依赖
config.json 原子写入会在配置目录留下短暂的 config.json.<random>.tmp 临时文件，正常路径下立即被 os.replace 消费；只在写入过程中崩溃才会残留，可安全清理
removeEventFilter 在 Qt 中幂等，与现有 _quit() 路径并存安全
Out of scope (next batch)
审计还发现以下问题，因改动量较大或风险较高单独成 PR：

settings_window 的 TestConnectionWorker / FetchModelsWorker 阻塞在 urlopen，quit() 无效，关窗仍运行
model_manager.get_model_json_path 缺路径遍历校验（character 来自可被外部编辑的 config.json）
llm_manager 未强制 https，HTTPError 响应未关闭
platform_patch 切换模型/纹理时未 glDeleteTextures → GPU 显存泄漏
_bleed_transparent_edges 性能 + 半透明像素被覆盖造成色斑
database_manager check_same_thread=False 但无锁
RadialMenu 窗口外点击不能 dismiss
Happy to file follow-up PRs for any of these if you'd like.