### PR TITLE
fix: AMD GPU compatibility (shader compile + alpha-readback fallback)

### DIFF
--- a/live2d_widget.py
+++ b/live2d_widget.py
@@ -270,18 +270,19 @@ class Live2DWidget(QOpenGLWidget):
         model.Update()
         model.Draw()
 
-        if not self._alpha_readback_broken:
+        if not getattr(self, "_alpha_readback_broken", False):
             pw = max(1, int(self._cache_w * self._system_scale))
             ph = max(1, int(self._cache_h * self._system_scale))
-            if (self._alpha_cache is None
-                    or self._alpha_cache_w != pw
-                    or self._alpha_cache_h != ph):
-                self._alpha_cache = (ctypes.c_ubyte * (pw * ph * 4))()
+            cache = getattr(self, "_alpha_cache", None)
+            if (cache is None
+                    or getattr(self, "_alpha_cache_w", 0) != pw
+                    or getattr(self, "_alpha_cache_h", 0) != ph):
+                cache = (ctypes.c_ubyte * (pw * ph * 4))()
+                self._alpha_cache = cache
                 self._alpha_cache_w = pw
                 self._alpha_cache_h = ph
             try:
-                gl.glReadPixels(0, 0, pw, ph, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE,
-                                self._alpha_cache)
+                gl.glReadPixels(0, 0, pw, ph, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE, cache)
             except Exception:
                 pass
 
@@ -393,7 +394,7 @@ class Live2DWidget(QOpenGLWidget):
                 pass
         if self._alpha_near(x, y) > self._hit_alpha_threshold:
             return True
-        if self._alpha_readback_broken:
+        if getattr(self, "_alpha_readback_broken", False):
             # Drivers with broken alpha readback (AMD on Qt6 + DWM): use an
             # ellipse approximating the typical Live2D character silhouette.
             # Less precise than per-pixel alpha, but lets the widget corners
@@ -422,12 +423,14 @@ class Live2DWidget(QOpenGLWidget):
             return 0
         if x < 0 or y < 0 or x >= self._cache_w or y >= self._cache_h:
             return 0
-        cache = self._alpha_cache
-        if cache is None or self._alpha_cache_w == 0:
+        cache = getattr(self, "_alpha_cache", None)
+        cw = getattr(self, "_alpha_cache_w", 0)
+        ch = getattr(self, "_alpha_cache_h", 0)
+        if cache is None or cw == 0:
             return 0
         sx = int(x * self._system_scale)
         sy = int((self._cache_h - y) * self._system_scale)
-        if sx < 0 or sx >= self._alpha_cache_w or sy < 0 or sy >= self._alpha_cache_h:
+        if sx < 0 or sx >= cw or sy < 0 or sy >= ch:
             return 0
-        idx = (sy * self._alpha_cache_w + sx) * 4 + 3
+        idx = (sy * cw + sx) * 4 + 3
         return cache[idx]

--- a/live2d_widget.py
+++ b/live2d_widget.py
@@ -383,7 +383,7 @@ class Live2DWidget(QOpenGLWidget):
                     return True
             except Exception:
                 pass
-        if self._get_alpha_fast(x, y) > 8:
+        if self._alpha_near(x, y) > self._hit_alpha_threshold:
             return True
         if self._alpha_readback_broken:
             margin_x = self._cache_w * 0.12
@@ -391,6 +391,14 @@ class Live2DWidget(QOpenGLWidget):
             return (margin_x <= x < self._cache_w - margin_x
                     and margin_top <= y < self._cache_h)
         return False
+
+    def _alpha_near(self, x: float, y: float) -> int:
+        alpha = 0
+        for dx, dy in self._hit_probe_offsets:
+            alpha = max(alpha, self._get_alpha_fast(x + dx, y + dy))
+            if alpha > self._hit_alpha_threshold:
+                break
+        return alpha
 
     def _get_alpha_fast(self, x: float, y: float) -> int:
         if not self._initialized_gl or not self._model:

--- a/live2d_widget.py
+++ b/live2d_widget.py
@@ -76,6 +76,16 @@ class Live2DWidget(QOpenGLWidget):
         # 极限优化：预分配底层 C 内存
         self._pixel_buf = (ctypes.c_ubyte * 4)()
 
+        # alpha 缓存（在 paintGL 内填充）。某些驱动（已知 AMD on Qt6）的 QOpenGLWidget
+        # FBO 在 paintGL 之外读到的 alpha 通道全是 0，无法可靠 hit-test。我们在 paintGL
+        # 里把整张 RGBA 拷到内存，hit-test 直接 CPU 查表，规避驱动差异。
+        self._alpha_cache = None
+        self._alpha_cache_w = 0
+        self._alpha_cache_h = 0
+        # 启动时由 initializeGL 检测：alpha buffer 完全坏掉时，跳过 alpha 路径，
+        # 用矩形 fallback 维持基本可交互性。
+        self._alpha_readback_broken = False
+
         self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
@@ -196,6 +206,13 @@ class Live2DWidget(QOpenGLWidget):
             self._live2d.glInit()
         self._system_scale = QGuiApplication.primaryScreen().devicePixelRatio()
         self._initialized_gl = True
+
+        try:
+            vendor_raw = gl.glGetString(gl.GL_VENDOR) or b""
+            vendor = vendor_raw.decode("utf-8", errors="ignore").upper()
+            self._alpha_readback_broken = "AMD" in vendor or "ATI" in vendor
+        except Exception:
+            self._alpha_readback_broken = False
         
         self._cache_w = self.width()
         self._cache_h = self.height()
@@ -244,6 +261,22 @@ class Live2DWidget(QOpenGLWidget):
         gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_STENCIL_BUFFER_BIT)
         model.Update()
         model.Draw()
+
+        if not self._alpha_readback_broken:
+            pw = max(1, int(self._cache_w * self._system_scale))
+            ph = max(1, int(self._cache_h * self._system_scale))
+            if (self._alpha_cache is None
+                    or self._alpha_cache_w != pw
+                    or self._alpha_cache_h != ph):
+                self._alpha_cache = (ctypes.c_ubyte * (pw * ph * 4))()
+                self._alpha_cache_w = pw
+                self._alpha_cache_h = ph
+            try:
+                gl.glReadPixels(0, 0, pw, ph, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE,
+                                self._alpha_cache)
+            except Exception:
+                pass
+
         if self._static_render:
             self._static_render_done = True
 
@@ -341,28 +374,35 @@ class Live2DWidget(QOpenGLWidget):
         return self._is_model_hit_at(local.x(), local.y())
 
     def _is_model_hit_at(self, x: float, y: float) -> bool:
-        model = self._model
-        if not model:
+        if x < 0 or y < 0 or x >= self._cache_w or y >= self._cache_h:
             return False
-        try:
-            if hasattr(model, "HitPart"):
-                return bool(model.HitPart(x, y, topOnly=True))
-        except Exception:
-            pass
-        return self._get_alpha_fast(x, y) > 8
+        model = self._model
+        if model and hasattr(model, "HitPart"):
+            try:
+                if bool(model.HitPart(x, y, topOnly=True)):
+                    return True
+            except Exception:
+                pass
+        if self._get_alpha_fast(x, y) > 8:
+            return True
+        if self._alpha_readback_broken:
+            margin_x = self._cache_w * 0.12
+            margin_top = self._cache_h * 0.08
+            return (margin_x <= x < self._cache_w - margin_x
+                    and margin_top <= y < self._cache_h)
+        return False
 
     def _get_alpha_fast(self, x: float, y: float) -> int:
         if not self._initialized_gl or not self._model:
             return 0
         if x < 0 or y < 0 or x >= self._cache_w or y >= self._cache_h:
             return 0
-            
-        try:
-            self._safe_make_current()
-            sx = int(x * self._system_scale)
-            sy = int((self._cache_h - y) * self._system_scale)
-            
-            gl.glReadPixels(sx, sy, 1, 1, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE, self._pixel_buf)
-            return self._pixel_buf[3]
-        except Exception:
+        cache = self._alpha_cache
+        if cache is None or self._alpha_cache_w == 0:
             return 0
+        sx = int(x * self._system_scale)
+        sy = int((self._cache_h - y) * self._system_scale)
+        if sx < 0 or sx >= self._alpha_cache_w or sy < 0 or sy >= self._alpha_cache_h:
+            return 0
+        idx = (sy * self._alpha_cache_w + sx) * 4 + 3
+        return cache[idx]

--- a/live2d_widget.py
+++ b/live2d_widget.py
@@ -394,10 +394,19 @@ class Live2DWidget(QOpenGLWidget):
         if self._alpha_near(x, y) > self._hit_alpha_threshold:
             return True
         if self._alpha_readback_broken:
-            margin_x = self._cache_w * 0.12
-            margin_top = self._cache_h * 0.08
-            return (margin_x <= x < self._cache_w - margin_x
-                    and margin_top <= y < self._cache_h)
+            # Drivers with broken alpha readback (AMD on Qt6 + DWM): use an
+            # ellipse approximating the typical Live2D character silhouette.
+            # Less precise than per-pixel alpha, but lets the widget corners
+            # remain click-through to whatever's behind the pet.
+            cx = self._cache_w * 0.5
+            cy = self._cache_h * 0.55
+            rx = self._cache_w * 0.30
+            ry = self._cache_h * 0.45
+            if rx <= 0 or ry <= 0:
+                return False
+            nx = (x - cx) / rx
+            ny = (y - cy) / ry
+            return nx * nx + ny * ny <= 1.0
         return False
 
     def _alpha_near(self, x: float, y: float) -> int:

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import QApplication, QMenu, QSystemTrayIcon
 from qfluentwidgets import setTheme, Theme
 
 import live2d.v2 as live2d
-from platform_patch import PatchedPlatformManager
+from platform_patch import PatchedPlatformManager, patch_live2d_shader_compat
 from live2d_widget import Live2DWidget
 from model_manager import ModelManager
 from config_manager import ConfigManager
@@ -32,6 +32,7 @@ def main():
         lang = detect_system_language()
     set_language(lang)
 
+    patch_live2d_shader_compat()
     live2d.init()
 
     live2d.Live2DFramework.setPlatformManager(

--- a/pet_process.py
+++ b/pet_process.py
@@ -20,7 +20,7 @@ from i18n_manager import current_language, detect_system_language, set_language
 from live2d_widget import Live2DWidget
 from model_manager import ModelManager
 from pet_window import PetWindow
-from platform_patch import PatchedPlatformManager
+from platform_patch import PatchedPlatformManager, patch_live2d_shader_compat
 
 
 def _parse_args():
@@ -46,6 +46,7 @@ def main():
     cfg = ConfigManager()
     set_language(cfg.get("language", "") or detect_system_language())
 
+    patch_live2d_shader_compat()
     live2d.init()
     live2d.Live2DFramework.setPlatformManager(
         PatchedPlatformManager(live2d.Live2DFramework.getPlatformManager())

--- a/pet_window.py
+++ b/pet_window.py
@@ -145,7 +145,7 @@ class PetWindow(QWidget):
         self._stack.addWidget(self._pixel_widget)
 
     def nativeEvent(self, event_type, message):
-        if os.name == "nt":
+        if os.name == "nt" and not getattr(self._live2d_widget, "_alpha_readback_broken", False):
             try:
                 msg = ctypes.wintypes.MSG.from_address(int(message))
                 if msg.message == WM_NCHITTEST:
@@ -199,6 +199,9 @@ class PetWindow(QWidget):
 
     def _update_mouse_passthrough(self):
         if os.name != "nt" or not self.isVisible():
+            return
+        if getattr(self._live2d_widget, "_alpha_readback_broken", False):
+            self._set_mouse_passthrough(False)
             return
         if self._live2d_widget._dragging or self._pixel_widget._dragging:
             return

--- a/platform_patch.py
+++ b/platform_patch.py
@@ -8,6 +8,43 @@ BASE_DIR = str(app_base_dir())
 MODELS_DIR = os.path.join(BASE_DIR, "models")
 
 
+def patch_live2d_shader_compat():
+    """Patch live2d-py V2 fragment shaders to compile on strict GLSL drivers.
+
+    Live2D V2's bundled fragment shader source uses ``#version 120`` together
+    with ``precision mediump float;``. The latter is GLSL ES syntax and is not
+    valid in desktop GLSL 1.20. NVIDIA drivers silently accept it as an
+    extension; AMD drivers (and likely Intel on Mesa) reject it strictly,
+    causing the fragment shader to fail compilation, the program to fail
+    linking, and the next ``glGetAttribLocation`` to raise GL_INVALID_OPERATION
+    on startup.
+
+    Bumping the directive to ``#version 130`` keeps ``varying`` /
+    ``gl_FragColor`` / ``texture2D`` (compatibility profile keeps these) while
+    making ``precision`` qualifiers valid, so all three vendors compile.
+    Idempotent — safe to call multiple times. Must be called before
+    ``live2d.init()``.
+    """
+    try:
+        from live2d.v2.core.graphics import draw_param_opengl as _dpgl
+    except Exception:
+        return  # live2d-py not on path yet; caller should retry post-init
+
+    cls = getattr(_dpgl, "DrawParamOpenGL", None)
+    if cls is None or getattr(cls, "_bandori_shader_compat_patched", False):
+        return
+
+    original = cls.compileShader
+
+    def _compileShader_compat(self, shader_type, source):
+        if isinstance(source, str) and "#version 120" in source and "precision mediump" in source:
+            source = source.replace("#version 120", "#version 130", 1)
+        return original(self, shader_type, source)
+
+    cls.compileShader = _compileShader_compat
+    cls._bandori_shader_compat_patched = True
+
+
 def _bleed_transparent_edges(image: Image.Image, passes: int = 2) -> Image.Image:
     pixels = image.load()
     width, height = image.size


### PR DESCRIPTION
Two real bugs that block all AMD GPU users on Qt6 + Windows. Both discovered while debugging on AMD Radeon 890M (Ryzen AI laptop iGPU); likely affect every AMD GPU and possibly Intel/Mesa with strict GLSL.

1. live2d-py V2's bundled fragment shader source uses

       #version 120
       precision mediump float;
       ...

   `precision mediump float;` is GLSL ES syntax and is **not valid in desktop GLSL 1.20**. NVIDIA accepts it as a silent extension; AMD strictly rejects it, so the fragment shader fails to compile, the program fails to link, and the next call into the live2d-py shader pipeline raises:

       OpenGL.error.GLError(err = 1282 / GL_INVALID_OPERATION,
                            baseOperation = glGetAttribLocation,
                            cArguments = (1, b'a_position\x00'))

   crashing pet_process before the model can render. Fix: monkey-patch `DrawParamOpenGL.compileShader` from `platform_patch` to upgrade `#version 120` to `#version 130` when the source contains `precision mediump`. GLSL 1.30 compatibility profile keeps `varying` / `gl_FragColor` / `texture2D`, so existing shader bodies still work. The patch is idempotent and only fires when the source matches, so it's a no-op once live2d-py upstream fixes their shaders.

2. Even after the model renders, AMD's Qt6 QOpenGLWidget appears to discard the FBO's alpha channel between paintGL calls. `glReadPixels` from outside paintGL returns alpha = 0 everywhere; even from inside paintGL it returns 0. The pet relied on alpha sampling for two things: `WM_NCHITTEST` returning HTTRANSPARENT to make empty pixels click-through, and a 50ms timer toggling `WS_EX_TRANSPARENT` for the whole window. With alpha permanently 0, both code paths conclude the user is never over the model -> the entire window becomes click- through at the OS level -> no drag, no click, no menu, only the character's eye-tracking (which uses QCursor.pos directly) still works.

   Fix:
   - `Live2DWidget.initializeGL` reads `GL_VENDOR` and sets `_alpha_readback_broken = True` for AMD/ATI.
   - `_update_mouse_passthrough` and `nativeEvent`'s WM_NCHITTEST branch short-circuit on that flag so the whole widget rect stays interactive (loses precise per-pixel passthrough on AMD, but the pet is usable).
   - `_is_model_hit_at` becomes three-tier (HitPart -> alpha cache -> widget-rect fallback), so V2 models without hit_areas still drag correctly on AMD.
   - The per-frame `glReadPixels` is moved from `_get_alpha_fast` into `paintGL` and cached, then `_get_alpha_fast` becomes a CPU lookup. This is a perf win for everyone (no GPU sync per hover) and on AMD it's skipped entirely via `_alpha_readback_broken`.

NVIDIA / Intel-with-permissive-GLSL users are unaffected: the shader patch is a no-op once shaders compile, vendor detection skips the fallback path, and the in-paintGL alpha cache replaces the old on-demand readback transparently.