### PR TITLE
Fix settings window app icon

### DIFF
--- a/process_utils.py
+++ b/process_utils.py
@@ -21,6 +21,17 @@ def process_program_and_args(base_dir: str, script_name: str, args: list[str]) -
     return sys.executable, [os.path.join(base_dir, script_name), *args]
 
 
+def set_windows_app_user_model_id(app_id: str) -> None:
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_id)
+    except Exception:
+        pass
+
+
 def ipc_server_name() -> str:
     digest = hashlib.sha1(str(app_base_dir()).encode("utf-8")).hexdigest()[:12]
     return f"BandoriPet-{digest}"

--- a/settings_process.py
+++ b/settings_process.py
@@ -2,11 +2,12 @@ import argparse
 import os
 import sys
 
-from process_utils import app_base_dir, ipc_server_name
+from process_utils import app_base_dir, ipc_server_name, set_windows_app_user_model_id
 
 BASE_DIR = str(app_base_dir())
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
 from PySide6.QtNetwork import QLocalSocket
 from PySide6.QtWidgets import QApplication
 
@@ -29,6 +30,12 @@ def _parse_args():
     return parser.parse_args()
 
 
+def _apply_app_icon(app: QApplication) -> None:
+    icon_path = os.path.join(BASE_DIR, "logo.ico")
+    if os.path.exists(icon_path):
+        app.setWindowIcon(QIcon(icon_path))
+
+
 def main():
     os.chdir(BASE_DIR)
     args = _parse_args()
@@ -39,10 +46,12 @@ def main():
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     QApplication.setAttribute(Qt.ApplicationAttribute.AA_UseDesktopOpenGL)
 
+    set_windows_app_user_model_id("BandoriPet.Settings")
     app = QApplication(sys.argv)
     app.setApplicationName("BandoriPetSettings")
     app.setOrganizationName("BandoriPet")
     app.setQuitOnLastWindowClosed(True)
+    _apply_app_icon(app)
 
     apply_app_theme(cfg.get("dark_theme", False))
 
@@ -83,8 +92,7 @@ def main():
         window.move((geo.width() - window.width()) // 2, (geo.height() - window.height()) // 2)
 
     window.show()
-    ret = app.exec()
-    return ret
+    return app.exec()
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,9 @@ icon = str(BASE_DIR / "logo.ico") if (BASE_DIR / "logo.ico").exists() else None
 
 executables = [
     Executable("main.py", base=base, target_name="BandoriPet.exe", icon=icon),
-    Executable("pet_process.py", base=base, target_name="pet_process.exe"),
-    Executable("settings_process.py", base=base, target_name="settings_process.exe"),
-    Executable("chat_process.py", base=base, target_name="chat_process.exe"),
+    Executable("pet_process.py", base=base, target_name="pet_process.exe", icon=icon),
+    Executable("settings_process.py", base=base, target_name="settings_process.exe", icon=icon),
+    Executable("chat_process.py", base=base, target_name="chat_process.exe", icon=icon),
 ]
 
 setup(


### PR DESCRIPTION
## Summary

- Set the settings process application icon from `logo.ico` before the settings window is shown.
- Add a Windows AppUserModelID helper so Windows can associate the settings window with the intended app identity instead of the generic Qt/Python icon.
- Include `logo.ico` on the packaged helper executables so `settings_process.exe`, `pet_process.exe`, and `chat_process.exe` no longer use the default executable icon.

## Validation

- `python -m py_compile settings_process.py process_utils.py setup.py`
- Offscreen Qt smoke test confirmed `_apply_app_icon()` loads a non-null application icon.
