### PR TITLE
Persist Live2D click action settings

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -13,6 +13,7 @@ DEFAULTS = {
     "character": "",
     "costume": "",
     "models": [],
+    "model_action_settings": {},
     "language": "",
     "fps": 120,
     "opacity": 1.0,
@@ -56,6 +57,35 @@ MODEL_DEFAULTS = {
     "click_motion_actions": {},
 }
 
+MODEL_ACTION_KEYS = (
+    "default_motion",
+    "default_expression",
+    "click_motion_actions",
+)
+
+
+def model_action_settings_key(character: str, costume: str) -> str:
+    return f"{character}\t{costume}"
+
+
+def normalize_model_action_profile(profile) -> dict:
+    if not isinstance(profile, dict):
+        return {}
+
+    normalized = {}
+    default_motion = str(profile.get("default_motion", "") or "").strip()
+    default_expression = str(profile.get("default_expression", "") or "").strip()
+    click_motion_actions = normalize_click_motion_actions(
+        profile.get("click_motion_actions", {})
+    )
+    if default_motion:
+        normalized["default_motion"] = default_motion
+    if default_expression:
+        normalized["default_expression"] = default_expression
+    if click_motion_actions:
+        normalized["click_motion_actions"] = click_motion_actions
+    return normalized
+
 
 class ConfigManager:
     def __init__(self, path=CONFIG_PATH):
@@ -64,20 +94,53 @@ class ConfigManager:
         self.load()
 
     def load(self):
+        loaded = None
+        has_action_settings = False
         if self._path.exists():
             try:
                 with open(self._path, "r", encoding="utf-8") as f:
                     loaded = json.load(f)
+                has_action_settings = isinstance(loaded, dict) and "model_action_settings" in loaded
                 for k in DEFAULTS:
                     if k in loaded:
                         self._data[k] = loaded[k]
             except (json.JSONDecodeError, OSError):
                 pass
+        if loaded is None or not has_action_settings:
+            self._data["model_action_settings"] = {}
+        self._normalize_model_action_settings()
         self._normalize_models()
+        if not has_action_settings:
+            self._seed_model_action_settings_from_models()
         if not isinstance(self._data.get("chat_avatar_paths"), dict):
             self._data["chat_avatar_paths"] = {}
         if self._data.get("user_avatar_color") == "#2aabee":
             self._data["user_avatar_color"] = BANDORI_PRIMARY
+
+    def _normalize_model_action_settings(self):
+        profiles = self._data.get("model_action_settings", {})
+        if not isinstance(profiles, dict):
+            self._data["model_action_settings"] = {}
+            return
+
+        normalized = {}
+        for key, profile in profiles.items():
+            profile = normalize_model_action_profile(profile)
+            if profile:
+                normalized[str(key)] = profile
+        self._data["model_action_settings"] = normalized
+
+    def _seed_model_action_settings_from_models(self):
+        profiles = dict(self._data.get("model_action_settings", {}))
+        for item in self._data.get("models", []):
+            if not isinstance(item, dict):
+                continue
+            character = item.get("character", "")
+            costume = item.get("costume", "")
+            profile = normalize_model_action_profile(item)
+            if character and costume and profile:
+                profiles[model_action_settings_key(character, costume)] = profile
+        self._data["model_action_settings"] = profiles
 
     def _normalize_models(self):
         models = self._data.get("models", [])
@@ -95,6 +158,10 @@ class ConfigManager:
                 continue
             entry = dict(MODEL_DEFAULTS)
             entry.update(item)
+            profile = self.get_model_action_profile(character, costume)
+            for key in MODEL_ACTION_KEYS:
+                if not item.get(key) and profile.get(key):
+                    entry[key] = profile[key]
             entry["click_motion_actions"] = normalize_click_motion_actions(
                 entry.get("click_motion_actions", {})
             )
@@ -137,6 +204,31 @@ class ConfigManager:
 
     def update(self, d: dict):
         self._data.update(d)
+
+    def get_model_action_profile(self, character: str, costume: str) -> dict:
+        profiles = self._data.get("model_action_settings", {})
+        if not isinstance(profiles, dict):
+            return {}
+        key = model_action_settings_key(str(character or ""), str(costume or ""))
+        return dict(profiles.get(key, {}))
+
+    def set_model_action_profile(self, character: str, costume: str, profile):
+        character = str(character or "")
+        costume = str(costume or "")
+        if not character or not costume:
+            return
+        profiles = self._data.get("model_action_settings", {})
+        if not isinstance(profiles, dict):
+            profiles = {}
+        else:
+            profiles = dict(profiles)
+        key = model_action_settings_key(character, costume)
+        normalized = normalize_model_action_profile(profile)
+        if normalized:
+            profiles[key] = normalized
+        else:
+            profiles.pop(key, None)
+        self._data["model_action_settings"] = profiles
 
     @property
     def data(self):

--- a/main.py
+++ b/main.py
@@ -235,6 +235,10 @@ def main():
         cfg.set("game_topmost", pet_window_ref["game_topmost"])
         cfg.set("live2d_quality", pet_window_ref["live2d_quality"])
         cfg.set("live2d_scale", pet_window_ref["live2d_scale"])
+        if "model_action_settings" in data:
+            cfg.set("model_action_settings", data["model_action_settings"])
+        if "models" in data:
+            cfg.set("models", data["models"])
         cfg.save()
 
     def launch_pet():

--- a/pet_window.py
+++ b/pet_window.py
@@ -450,11 +450,28 @@ class PetWindow(QWidget):
         if not self._cfg:
             return {}
         models = self._cfg.get("models", [])
+        fallback = None
         if isinstance(models, list):
             for item in models:
-                if isinstance(item, dict) and item.get("character") == self._current_char:
-                    return item
-        return {}
+                if not isinstance(item, dict) or item.get("character") != self._current_char:
+                    continue
+                if item.get("costume") == self._current_costume:
+                    return self._with_saved_action_profile(item)
+                if fallback is None:
+                    fallback = item
+        return self._with_saved_action_profile(fallback or {})
+
+    def _with_saved_action_profile(self, entry: dict) -> dict:
+        if not self._cfg or not hasattr(self._cfg, "get_model_action_profile"):
+            return entry
+        profile = self._cfg.get_model_action_profile(self._current_char, self._current_costume)
+        if not profile:
+            return entry
+        merged = dict(entry)
+        for key in ("default_motion", "default_expression", "click_motion_actions"):
+            if not merged.get(key) and profile.get(key):
+                merged[key] = profile[key]
+        return merged
 
     def _configured_pet_mode(self) -> str:
         if not self._cfg:
@@ -504,6 +521,10 @@ class PetWindow(QWidget):
             self._live2d_widget.set_render_quality(self._live2d_quality)
         if "live2d_scale" in data:
             self.set_live2d_scale(data["live2d_scale"])
+        if self._cfg and ("models" in data or "model_action_settings" in data):
+            self._cfg.load()
+        if "model_action_settings" in data and self._cfg:
+            self._cfg.set("model_action_settings", data["model_action_settings"])
         if "models" in data and self._cfg:
             self._cfg.set("models", data["models"])
             self._cfg.save()
@@ -1365,6 +1386,8 @@ class PetWindow(QWidget):
         click_motion_actions = self._current_model_entry().get("click_motion_actions", {})
         if click_motion_actions:
             entry["click_motion_actions"] = click_motion_actions
+        if hasattr(self._cfg, "set_model_action_profile"):
+            self._cfg.set_model_action_profile(self._current_char, self._current_costume, entry)
         entry["pet_mode"] = "pixel" if self._pixel_mode else "live2d"
         if self._pixel_mode:
             entry.update({
@@ -1378,14 +1401,29 @@ class PetWindow(QWidget):
                 "window_width": self.width(),
                 "window_height": self.height(),
             })
+        updated = False
         for idx, item in enumerate(models):
-            if isinstance(item, dict) and item.get("character") == self._current_char:
+            if (
+                isinstance(item, dict)
+                and item.get("character") == self._current_char
+                and item.get("costume") == self._current_costume
+            ):
                 preserved = dict(item)
                 preserved.update(entry)
                 entry = preserved
                 models[idx] = entry
+                updated = True
                 break
-        else:
+        if not updated:
+            for idx, item in enumerate(models):
+                if isinstance(item, dict) and item.get("character") == self._current_char:
+                    preserved = dict(item)
+                    preserved.update(entry)
+                    entry = preserved
+                    models[idx] = entry
+                    updated = True
+                    break
+        if not updated:
             models.append(entry)
         self._cfg.set("models", models)
         if save:

--- a/settings_window.py
+++ b/settings_window.py
@@ -776,6 +776,7 @@ class SettingsWindow(QWidget):
                     continue
                 entry = dict(item)
                 entry.update({"character": character, "costume": costume, "path": path})
+                self._restore_model_action_profile(entry, prefer_existing=True)
                 entry["click_motion_actions"] = normalize_click_motion_actions(
                     entry.get("click_motion_actions", {})
                 )
@@ -792,6 +793,30 @@ class SettingsWindow(QWidget):
                     "click_motion_actions": {},
                 })
         return result
+
+    def _restore_model_action_profile(self, entry: dict, prefer_existing: bool = False):
+        if not self._cfg or not hasattr(self._cfg, "get_model_action_profile"):
+            return
+        profile = self._cfg.get_model_action_profile(
+            entry.get("character", ""),
+            entry.get("costume", ""),
+        )
+        if not profile:
+            return
+        for key in ("default_motion", "default_expression", "click_motion_actions"):
+            if prefer_existing and entry.get(key):
+                continue
+            if profile.get(key):
+                entry[key] = profile[key]
+
+    def _archive_model_action_profile(self, entry: dict):
+        if not self._cfg or not hasattr(self._cfg, "set_model_action_profile"):
+            return
+        self._cfg.set_model_action_profile(
+            entry.get("character", ""),
+            entry.get("costume", ""),
+            entry,
+        )
 
     def _on_language_changed(self, index: int):
         lang = self._lang_combo.itemData(index)
@@ -2564,6 +2589,8 @@ class SettingsWindow(QWidget):
     def _save_configured_models(self):
         if not self._cfg:
             return
+        for item in self._configured_models:
+            self._archive_model_action_profile(item)
         selected = self._selected_model_item()
         if selected:
             self._cfg.set("character", selected["character"])
@@ -2667,6 +2694,7 @@ class SettingsWindow(QWidget):
             "default_expression": "",
             "click_motion_actions": {},
         }
+        self._restore_model_action_profile(entry)
         replace_index = self._editing_model_index
         if replace_index is None and not self._adding_model:
             replace_character = self._editing_list_character or self._selected_list_character
@@ -2675,19 +2703,25 @@ class SettingsWindow(QWidget):
                     replace_index = idx
                     break
         if replace_index is not None and 0 <= replace_index < len(self._configured_models):
+            previous = self._configured_models[replace_index]
+            self._archive_model_action_profile(previous)
             preserved = dict(self._configured_models[replace_index])
             preserved.update(entry)
-            for key in (
+            preserve_keys = (
                 "window_x",
                 "window_y",
                 "window_width",
                 "window_height",
                 "pixel_window_x",
                 "pixel_window_y",
-                "default_motion",
-                "default_expression",
-                "click_motion_actions",
-            ):
+            )
+            if previous.get("character") == character and previous.get("costume") == costume:
+                preserve_keys += (
+                    "default_motion",
+                    "default_expression",
+                    "click_motion_actions",
+                )
+            for key in preserve_keys:
                 if key in self._configured_models[replace_index]:
                     preserved[key] = self._configured_models[replace_index][key]
             entry = preserved
@@ -2695,19 +2729,24 @@ class SettingsWindow(QWidget):
         else:
             for idx, item in enumerate(self._configured_models):
                 if item["character"] == character:
+                    self._archive_model_action_profile(item)
                     preserved = dict(item)
                     preserved.update(entry)
-                    for key in (
+                    preserve_keys = (
                         "window_x",
                         "window_y",
                         "window_width",
                         "window_height",
                         "pixel_window_x",
                         "pixel_window_y",
-                        "default_motion",
-                        "default_expression",
-                        "click_motion_actions",
-                    ):
+                    )
+                    if item.get("costume") == costume:
+                        preserve_keys += (
+                            "default_motion",
+                            "default_expression",
+                            "click_motion_actions",
+                        )
+                    for key in preserve_keys:
                         if key in item:
                             preserved[key] = item[key]
                     entry = preserved
@@ -2849,6 +2888,7 @@ class SettingsWindow(QWidget):
             "live2d_quality": self._live2d_quality,
             "live2d_scale": self._live2d_scale,
             "models": [dict(item) for item in self._configured_models],
+            "model_action_settings": self._cfg.get("model_action_settings", {}) if self._cfg else {},
         }
         if self._cfg:
             self._cfg.set("fps", settings["fps"])


### PR DESCRIPTION
## Summary

- Add a persistent model_action_settings config map keyed by character and costume.
- Restore default motion, default expression, and click motion actions when a Live2D model is switched back in.
- Keep settings process, pet process, and main process synchronization aware of the archived action settings.

## Why

Live2D click feedback settings were stored only on the active configured model entry. When users changed characters or costumes, the new entry could overwrite those custom actions with defaults, so returning to the previous model lost its click-triggered motion settings.

## Validation

- Ran Python bytecode compilation for the changed modules.
- Verified with a temporary config that model A's click action profile survives switching to model B and is restored when model A is re-added.