### PR TITLE
Fix macOS-specific window-behavior bugs

### DIFF
--- a/chat_window.py
+++ b/chat_window.py
@@ -29,6 +29,7 @@ from app_theme import (
 import ctypes
 import os
 import shutil
+import sys
 from datetime import datetime
 import json
 import re
@@ -36,6 +37,11 @@ from pathlib import Path
 
 if os.name == "nt":
     import ctypes.wintypes
+
+if sys.platform == "darwin":
+    import macos_patch
+else:
+    macos_patch = None
 
 from llm_manager import (
     build_system_prompt, LLMStreamWorker, NonStreamWorker,
@@ -832,9 +838,20 @@ class ChatWindow(QWidget):
     def showEvent(self, event):
         super().showEvent(event)
         self._apply_windows_11_border_fix()
+        if macos_patch is not None:
+            QTimer.singleShot(0, self._apply_macos_window_polish)
         if not hasattr(self, '_entrance_done'):
             self._entrance_done = True
             QTimer.singleShot(0, self._play_entrance)
+
+    def _apply_macos_window_polish(self):
+        if macos_patch is None:
+            return
+        macos_patch.set_window_no_shadow(self)
+        macos_patch.set_window_level_floating(self)
+        # Tool window = NSPanel; default hidesOnDeactivate makes it disappear
+        # whenever the user clicks another app. Pin the chat visible.
+        macos_patch.set_hides_on_deactivate(self, False)
 
     def _apply_windows_11_border_fix(self):
         if os.name != "nt" or _dwm_set_window_attribute is None:

--- a/compact_ai_window.py
+++ b/compact_ai_window.py
@@ -1,6 +1,7 @@
 import ctypes
 import ctypes.wintypes
 import os
+import sys
 from datetime import datetime
 
 from PySide6.QtCore import QEvent, QEasingCurve, QPoint, QPropertyAnimation, Qt, QTimer, Signal, QRect
@@ -40,6 +41,11 @@ if os.name == "nt":
     _dwm_set_window_attribute.restype = ctypes.c_long
 else:
     _dwm_set_window_attribute = None
+
+if sys.platform == "darwin":
+    import macos_patch
+else:
+    macos_patch = None
 
 
 def _color_from_config(value: str, alpha: int) -> QColor:
@@ -396,6 +402,18 @@ class CompactAIWindow(QWidget):
     def showEvent(self, event):
         super().showEvent(event)
         self._apply_windows_frameless_fix()
+        if macos_patch is not None:
+            QTimer.singleShot(0, self._apply_macos_window_polish)
+
+    def _apply_macos_window_polish(self):
+        if macos_patch is None:
+            return
+        macos_patch.set_window_no_shadow(self)
+        macos_patch.set_window_level_floating(self)
+        # Tool window = NSPanel; default hidesOnDeactivate makes it disappear
+        # whenever the user clicks another app. Pin it visible.
+        macos_patch.set_hides_on_deactivate(self, False)
+        macos_patch.set_collection_behavior(self, macos_patch.PET_COLLECTION_BEHAVIOR)
 
     def nativeEvent(self, event_type, message):
         if os.name == "nt":

--- a/macos_patch.py
+++ b/macos_patch.py
@@ -66,6 +66,14 @@ def set_window_level_floating(widget) -> bool:
     return _set_window_level(widget, 3)
 
 
+def set_window_level_status_bar(widget) -> bool:
+    # NSStatusWindowLevel — high enough that AppKit's constrainFrameRect:toScreen:
+    # stops clamping the window to below the menu bar, so the user can drag the
+    # pet anywhere on screen even when the visible character is offset inside
+    # the window's transparent bounds.
+    return _set_window_level(widget, 25)
+
+
 def set_window_level_above_menu_bar(widget) -> bool:
     return _set_window_level(widget, 101)
 
@@ -103,6 +111,61 @@ def set_window_no_shadow(widget) -> bool:
     f = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool)
     sender = ctypes.cast(_OBJC.objc_msgSend, f)
     sender(window, _sel("setHasShadow:"), ctypes.c_bool(False))
+    return True
+
+
+def set_hides_on_deactivate(widget, hides: bool) -> bool:
+    # Qt.Tool maps to NSPanel on macOS, and NSPanel defaults to
+    # hidesOnDeactivate:YES — so any time the user clicks another app the
+    # window vanishes. Force it off so floating helpers stay visible.
+    if not _init_objc() or widget is None:
+        return False
+    try:
+        win_id = int(widget.winId())
+    except (TypeError, ValueError):
+        return False
+    if not win_id:
+        return False
+    window = _get_ns_window(win_id)
+    if not window:
+        return False
+    f = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool)
+    sender = ctypes.cast(_OBJC.objc_msgSend, f)
+    sender(window, _sel("setHidesOnDeactivate:"), ctypes.c_bool(hides))
+    return True
+
+
+# NSWindowCollectionBehavior bits used by the pet window so it shows up across
+# every Space and over fullscreen apps without joining the Cmd+~ cycle.
+NS_COLLECTION_CAN_JOIN_ALL_SPACES = 1 << 0
+NS_COLLECTION_STATIONARY = 1 << 4
+NS_COLLECTION_IGNORES_CYCLE = 1 << 6
+NS_COLLECTION_FULL_SCREEN_AUXILIARY = 1 << 8
+
+PET_COLLECTION_BEHAVIOR = (
+    NS_COLLECTION_CAN_JOIN_ALL_SPACES
+    | NS_COLLECTION_STATIONARY
+    | NS_COLLECTION_IGNORES_CYCLE
+    | NS_COLLECTION_FULL_SCREEN_AUXILIARY
+)
+
+
+def set_collection_behavior(widget, mask: int) -> bool:
+    if not _init_objc() or widget is None:
+        return False
+    try:
+        win_id = int(widget.winId())
+    except (TypeError, ValueError):
+        return False
+    if not win_id:
+        return False
+    window = _get_ns_window(win_id)
+    if not window:
+        return False
+    # NSWindowCollectionBehavior is NSUInteger (unsigned long on 64-bit darwin).
+    f = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_ulong)
+    sender = ctypes.cast(_OBJC.objc_msgSend, f)
+    sender(window, _sel("setCollectionBehavior:"), ctypes.c_ulong(int(mask)))
     return True
 
 

--- a/pet_window.py
+++ b/pet_window.py
@@ -385,13 +385,20 @@ class PetWindow(QWidget):
         )
 
     def _update_game_topmost_timer(self):
-        if os.name != "nt":
-            return
-        if self._game_topmost:
-            self._topmost_timer.start()
-            self._enforce_game_topmost()
-        else:
-            self._topmost_timer.stop()
+        if os.name == "nt":
+            if self._game_topmost:
+                self._topmost_timer.start()
+                self._enforce_game_topmost()
+            else:
+                self._topmost_timer.stop()
+        elif sys.platform == "darwin" and macos_patch is not None and self.isVisible():
+            # macOS: bump to pop-up-menu level (above almost everything) when
+            # game_topmost is on; otherwise sit at status-bar level so the
+            # window can still be dragged past the menu bar.
+            if self._game_topmost:
+                macos_patch.set_window_level_above_menu_bar(self)
+            else:
+                macos_patch.set_window_level_status_bar(self)
 
     def _enforce_game_topmost(self):
         if os.name != "nt" or not self._game_topmost or not self.isVisible():
@@ -408,6 +415,25 @@ class PetWindow(QWidget):
             0,
             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
         )
+
+    def _apply_macos_window_polish(self):
+        if sys.platform != "darwin" or macos_patch is None:
+            return
+        macos_patch.set_window_no_shadow(self)
+        # Status-bar level (25) bypasses macOS's auto-constrain so the user can
+        # drag the pet anywhere on screen — the Live2D widget has transparent
+        # padding around the visible character that would otherwise hit the
+        # menu bar before the character does.
+        if self._game_topmost:
+            macos_patch.set_window_level_above_menu_bar(self)
+        else:
+            macos_patch.set_window_level_status_bar(self)
+        # Qt.Tool windows are NSPanels, which AppKit hides whenever the app
+        # deactivates — clicking any other window would otherwise make the pet
+        # vanish. Force the panel to stay visible across app focus changes and
+        # across all Spaces.
+        macos_patch.set_hides_on_deactivate(self, False)
+        macos_patch.set_collection_behavior(self, macos_patch.PET_COLLECTION_BEHAVIOR)
 
     def eventFilter(self, obj, event):
         if self._radial_menu is not None and self._radial_menu.isVisible():
@@ -1801,12 +1827,12 @@ class PetWindow(QWidget):
     def showEvent(self, event):
         super().showEvent(event)
         self._apply_windows_frameless_fix()
-        self._update_game_topmost_timer()
         if sys.platform == "darwin" and macos_patch is not None:
-            QTimer.singleShot(0, lambda: (
-                macos_patch.set_window_no_shadow(self),
-                macos_patch.set_window_level_floating(self)
-            ))
+            QTimer.singleShot(0, self._apply_macos_window_polish)
+        # _update_game_topmost_timer reads isVisible(), so call it after show
+        # — and on macOS it depends on the NSWindow already existing, so defer
+        # to the next event loop tick alongside the polish call above.
+        QTimer.singleShot(0, self._update_game_topmost_timer)
         QTimer.singleShot(0, self._prewarm_radial_menu)
         if self._show_pos_set and self._is_position_on_screen():
             self._sync_compact_ai_window(allow_create=True)

--- a/radial_menu.py
+++ b/radial_menu.py
@@ -58,6 +58,11 @@ else:
     _set_window_pos = None
     _dwm_set_window_attribute = None
 
+if sys.platform == "darwin":
+    import macos_patch
+else:
+    macos_patch = None
+
 
 class RadialMenuItem(QWidget):
     clicked = Signal()
@@ -249,11 +254,22 @@ class RadialMenu(QWidget):
         super().showEvent(event)
         self._apply_windows_11_border_fix()
         QTimer.singleShot(0, self._apply_windows_11_border_fix)
+        if macos_patch is not None:
+            QTimer.singleShot(0, self._apply_macos_window_polish)
+
+    def _apply_macos_window_polish(self):
+        if macos_patch is None:
+            return
+        macos_patch.set_window_no_shadow(self)
+        # Use status-bar level so the menu stays above the floating pet window.
+        macos_patch.set_window_level_above_menu_bar(self)
 
     def prepare_for_show(self):
         # Force native window creation during idle time so first popup stays responsive.
         self.winId()
         self._apply_windows_11_border_fix()
+        if macos_patch is not None:
+            self._apply_macos_window_polish()
         self._prewarm_paint_cache()
 
     def _prewarm_paint_cache(self):


### PR DESCRIPTION
- macos_patch: add set_hides_on_deactivate / set_collection_behavior helpers and a NSStatusWindowLevel wrapper.
- pet_window/compact_ai_window/chat_window: in showEvent, force setHidesOnDeactivate:NO so Qt.Tool (NSPanel) windows don't vanish when the user clicks another app.
- pet_window: bump default macOS window level from NSFloatingWindowLevel (3) to NSStatusWindowLevel (25) so AppKit's constrainFrameRect:toScreen: no longer clamps the pet under the menu bar — the user can now drag the character past the screen top.
- pet_window: pet now sets a CanJoinAllSpaces | Stationary | IgnoresCycle | FullScreenAuxiliary collection behavior so it shows up across every Space and over fullscreen apps.
- radial_menu / compact_ai_window / chat_window: also call set_window_no_shadow on macOS, since NoDropShadowWindowHint is unreliable for translucent NSPanels.