### PR TITLE
修复 macOS 运行兼容性与窗口稳定性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ build/
 BandoriPet.egg-info/
 third_party/
 venv/
+.venv/
+.claude/
+*.app/
+*.command
 config.json
 data.*
 *.zip

--- a/live2d_lua_adapter.py
+++ b/live2d_lua_adapter.py
@@ -4,7 +4,10 @@ import os
 import random
 from pathlib import Path
 
-from lupa.luajit21 import LuaRuntime
+try:
+    from lupa.luajit21 import LuaRuntime
+except ModuleNotFoundError:
+    from lupa.lua import LuaRuntime
 from PIL import Image
 
 from platform_patch import get_live2d_texture_quality

--- a/lua_hit_area_projection.py
+++ b/lua_hit_area_projection.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 import sys
 
-from lupa.luajit21 import LuaRuntime
+try:
+    from lupa.luajit21 import LuaRuntime
+except ModuleNotFoundError:
+    from lupa.lua import LuaRuntime
 
 
 _LUA = LuaRuntime(unpack_returned_tuples=True)

--- a/pet_window.py
+++ b/pet_window.py
@@ -2,6 +2,7 @@ import ctypes
 import json
 import os
 import random
+import sys
 import re
 import time
 
@@ -30,7 +31,7 @@ from pixel_pet_widget import PixelPetWidget, load_pixel_frames, pixel_path_for_c
 from process_utils import app_base_dir, ipc_server_name, process_program_and_args
 from radial_menu import RadialMenu
 
-if os.name == "darwin":
+if sys.platform == "darwin":
     import macos_patch
 else:
     macos_patch = None
@@ -203,12 +204,16 @@ class PetWindow(QWidget):
         self.setWindowOpacity(self._opacity)
 
     def _init_ui(self):
-        self.setWindowFlags(
+        window_flags = (
             Qt.WindowType.FramelessWindowHint
             | Qt.WindowType.WindowStaysOnTopHint
-            | Qt.WindowType.Tool
             | Qt.WindowType.NoDropShadowWindowHint
         )
+        if sys.platform == "darwin":
+            window_flags |= Qt.WindowType.Window
+        else:
+            window_flags |= Qt.WindowType.Tool
+        self.setWindowFlags(window_flags)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
         self.setAttribute(Qt.WidgetAttribute.WA_AlwaysStackOnTop, True)
@@ -326,7 +331,7 @@ class PetWindow(QWidget):
             return
         if os.name == "nt":
             self._apply_passthrough_to_hwnd(int(self.winId()), enabled)
-        elif os.name == "darwin" and macos_patch is not None:
+        elif sys.platform == "darwin" and macos_patch is not None:
             macos_patch.set_ignores_mouse_events(self, enabled)
         else:
             return
@@ -1461,7 +1466,7 @@ class PetWindow(QWidget):
         super().showEvent(event)
         self._apply_windows_frameless_fix()
         self._update_game_topmost_timer()
-        if os.name == "darwin" and macos_patch is not None:
+        if sys.platform == "darwin" and macos_patch is not None:
             QTimer.singleShot(0, lambda: (
                 macos_patch.set_window_no_shadow(self),
                 macos_patch.set_window_level_floating(self)

--- a/settings_process.py
+++ b/settings_process.py
@@ -51,13 +51,6 @@ def main():
 
     app = QApplication(sys.argv)
 
-    if sys.platform == "darwin":
-        import macos_patch
-        macos_patch.hide_dock_icon()
-
-    if sys.platform == "darwin":
-        import macos_patch
-        macos_patch.hide_dock_icon()
     app.setApplicationName("BandoriPetSettings")
     app.setOrganizationName("BandoriPet")
     app.setQuitOnLastWindowClosed(True)

--- a/settings_window.py
+++ b/settings_window.py
@@ -6,7 +6,7 @@ from PySide6.QtGui import QFont, QColor, QPalette, QPixmap, QIcon, QCursor, QPai
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QGridLayout,
     QPushButton, QSizePolicy, QSpacerItem, QScrollArea,
-    QLineEdit, QGraphicsOpacityEffect, QGraphicsColorizeEffect, QApplication,
+    QLineEdit, QGraphicsOpacityEffect, QApplication,
     QTextEdit, QToolButton, QFileDialog, QMessageBox,
 )
 
@@ -602,37 +602,6 @@ class NavButton(QPushButton):
         self._update_stylesheet()
         qconfig.themeChanged.connect(self._update_stylesheet)
         self.clicked.connect(lambda: self.nav_activated.emit(self._nav_key))
-
-    def enterEvent(self, event):
-        if not self._checking_hover_effect():
-            self._apply_hover_effect(True)
-        super().enterEvent(event)
-
-    def leaveEvent(self, event):
-        self._apply_hover_effect(False)
-        super().leaveEvent(event)
-
-    def _checking_hover_effect(self):
-        eff = self.graphicsEffect()
-        return isinstance(eff, QGraphicsColorizeEffect) and eff.strength() > 0.0
-
-    def _apply_hover_effect(self, entering: bool):
-        eff = self.graphicsEffect()
-        if not isinstance(eff, QGraphicsColorizeEffect):
-            eff = QGraphicsColorizeEffect(self)
-            eff.setColor(QColor(BANDORI_PRIMARY_DARK))
-            eff.setStrength(0.0)
-            self.setGraphicsEffect(eff)
-        if hasattr(self, '_hover_anim'):
-            self._hover_anim.stop()
-        self._hover_anim = QPropertyAnimation(eff, b"strength")
-        self._hover_anim.setDuration(180)
-        self._hover_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
-        self._hover_anim.setStartValue(eff.strength())
-        self._hover_anim.setEndValue(0.35 if entering else 0.0)
-        if not entering:
-            self._hover_anim.finished.connect(lambda: self.setGraphicsEffect(None))
-        self._hover_anim.start()
 
     def _update_stylesheet(self):
         dark = isDarkTheme()
@@ -2172,21 +2141,6 @@ class SettingsWindow(QWidget):
             b.setChecked(False)
         btn.setChecked(True)
         self._style_avatar_buttons()
-        self._pulse_button(btn)
-
-    @staticmethod
-    def _pulse_button(btn):
-        effect = QGraphicsColorizeEffect(btn)
-        effect.setColor(QColor(255, 255, 255))
-        effect.setStrength(0.0)
-        btn.setGraphicsEffect(effect)
-        anim = QPropertyAnimation(effect, b"strength", btn)
-        anim.setDuration(120)
-        anim.setStartValue(0.7)
-        anim.setEndValue(0.0)
-        anim.setEasingCurve(QEasingCurve.Type.OutCubic)
-        anim.finished.connect(lambda: btn.setGraphicsEffect(None))
-        anim.start()
 
     def _load_llm_config(self):
         if self._cfg and self._llm_config_widgets_ready():


### PR DESCRIPTION
## 概要

- 为 Lupa 增加 `lupa.lua` fallback，兼容 macOS / Python 3.12 下链接系统 LuaJIT 构建出的模块名。
- 修复 macOS 下桌宠窗口在应用失焦后被系统隐藏的问题。
- 让设置窗口在 macOS 上作为正常窗口显示，便于从 Dock / 窗口切换中找回。
- 移除设置窗口中不稳定的 `QGraphicsColorizeEffect` hover 动画，避免 PySide6 原生段错误崩溃。

## 验证环境

- MacBook Pro（14 英寸，2023 年）
- Apple M2 Pro
- 16 GB 内存
- Python 3.12.10
- macOS 26.3