### PR TITLE
修复 Lupa LuaRuntime 导入兼容性

### DIFF
--- a/live2d_lua_adapter.py
+++ b/live2d_lua_adapter.py
@@ -5,7 +5,10 @@ import random
 import time
 from pathlib import Path
 
-from lupa.luajit21 import LuaRuntime
+try:
+    from lupa.luajit21 import LuaRuntime
+except ModuleNotFoundError:
+    from lupa.lua import LuaRuntime
 from PIL import Image
 
 from platform_patch import get_live2d_texture_quality

--- a/lua_hit_area_projection.py
+++ b/lua_hit_area_projection.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 import sys
 
-from lupa.luajit21 import LuaRuntime
+try:
+    from lupa.luajit21 import LuaRuntime
+except ModuleNotFoundError:
+    from lupa.lua import LuaRuntime
 
 
 _LUA = LuaRuntime(unpack_returned_tuples=True)


### PR DESCRIPTION
## 概要
- 为 Lupa 增加 `lupa.lua` fallback，兼容 macOS / Python 3.12 下链接系统 LuaJIT 构建出的模块名。
- 修复 `main` 分支在该环境下启动时因缺少 `lupa.luajit21` 而直接退出的问题。
- 同步处理 Live2D 适配层和自定义点击区域 Lua 投影逻辑，避免两处 LuaRuntime 导入路径不一致。

## 验证环境
- MacBook Pro（14 英寸，2023 年）
- Apple M2 Pro
- 16 GB 内存
- Python 3.12.10
- macOS 26.3