### PR TITLE
修复模型列表为空时 Live2D 未移除且重启后模型被回写的问题

### DIFF
--- a/pet_window.py
+++ b/pet_window.py
@@ -2011,14 +2011,13 @@ class PetWindow(QWidget):
             from qfluentwidgets import isDarkTheme
             self._cfg.load()
             models = self._cfg.get("models", [])
-            model_exists = (
-                not isinstance(models, list)
-                or not models
-                or any(
+            if isinstance(models, list):
+                model_exists = any(
                     isinstance(item, dict) and item.get("character") == self._current_char
                     for item in models
                 )
-            )
+            else:
+                model_exists = True
             self._cfg.set("language", current_language())
             path = self._model_manager.get_model_json_path(self._current_char, self._current_costume)
             if model_exists:

--- a/settings_window.py
+++ b/settings_window.py
@@ -5687,6 +5687,9 @@ class SettingsWindow(QWidget):
                 self._select_model_list_item(self._configured_models[0]["character"])
             else:
                 self._selected_list_character = ""
+                self._current_char = ""
+                self._current_costume = ""
+                self._selected_costume = ""
         self._refresh_model_list()
         if self._selected_list_character:
             self._show_model_detail()
@@ -5916,6 +5919,16 @@ class SettingsWindow(QWidget):
         if selected:
             self._current_char = selected["character"]
             self._selected_costume = selected["costume"]
+            self._current_costume = selected["costume"]
+        elif self._configured_models:
+            fallback = self._configured_models[0]
+            self._current_char = fallback["character"]
+            self._selected_costume = fallback["costume"]
+            self._current_costume = fallback["costume"]
+        else:
+            self._current_char = ""
+            self._selected_costume = ""
+            self._current_costume = ""
         if self._show_launch and not (self._current_char and self._selected_costume):
             self._launched = False
             InfoBar.warning(
@@ -5974,8 +5987,12 @@ class SettingsWindow(QWidget):
             self._cfg.set("live2d_quality", settings["live2d_quality"])
             self._cfg.set("live2d_scale", settings["live2d_scale"])
             self._cfg.save()
-        if self._current_char and self._selected_costume:
+        if self._configured_models:
             self.model_selected.emit(self._current_char, self._selected_costume)
+        else:
+            # Explicitly tell the main process there is no active model so it
+            # can relaunch with zero pet windows.
+            self.model_selected.emit("", "")
         self.settings_changed.emit(settings)
         if self._show_launch:
             self.launch_requested.emit()


### PR DESCRIPTION
## 背景 / 问题
当用户在设置页将模型列表清空并点击「应用」后，Live2D 仍可能继续显示；并且下次重启 App 时，被删除的模型会再次出现。

## 可复现平台
- macOS

## 根因分析
1. 设置页在模型列表为空时，仍可能保留旧的 `current_char/current_costume`，导致 IPC 仍发送旧模型信息。
2. `pet_window` 在关闭保存配置时，把“空模型列表”当作可回写当前模型，导致已删除模型被写回配置文件。

## 修复内容
1. 删除最后一个模型时，立即清空当前模型状态：
   - `settings_window.py` 的 `_remove_model_list_item`
2. 点击「应用」时，如果模型列表为空，显式发送空模型选择（`MODEL\t\t`）：
   - `settings_window.py` 的 `_on_apply`
3. 修正 `pet_window` 保存逻辑：当 `models` 是空列表时，不再回写当前模型：
   - `pet_window.py` 的 `_save_config`

## 验证步骤
1. 打开设置页，删除模型列表中的所有模型。
2. 点击「应用」。
3. 确认桌面上不再显示 Live2D 模型。
4. 关闭并重启 App。
5. 确认已删除模型不会再次出现。

## 影响范围
- 仅调整模型列表为空时的状态同步与保存判断。
- 不影响模型列表非空时的正常切换流程。