### PR TITLE
Fix group reply stream bubble routing

### DIFF
--- a/chat_window/chat_window.py
+++ b/chat_window/chat_window.py
@@ -50,6 +50,7 @@ from llm_manager import (
     consume_stream_action_tags, merged_action_tags, parse_action_tags, strip_action_tags, extract_inline_search_sources,
     estimate_llm_request_tokens,
 )
+from reply_stream import ReplyStreamBinding, is_active_reply_stream
 from emotion_behavior import emotion_tts_rate, infer_emotion_behavior
 from llm_api_compat import chat_completions_api_url, use_responses_api
 from llm_error_hints import format_llm_error_message
@@ -319,6 +320,9 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._cancelled_workers = []
         self._close_waiting_for_workers = False
         self._current_bubble: MessageBubble | None = None
+        self._reply_stream_generation = 0
+        self._active_reply_stream: ReplyStreamBinding | None = None
+        self._stream_buffer_owner: ReplyStreamBinding | None = None
         self._pending_actions: list[str] = []
         self._pending_action_character = character
         self._seen_actions: set[str] = set()
@@ -3596,6 +3600,7 @@ class ChatWindow(ChatWindowMixin, QWidget):
             self._park_cancelled_worker(worker)
             interrupted = True
         self._worker = None
+        self._clear_active_reply_stream()
 
         planner = self._group_plan_worker
         if planner is not None:
@@ -5417,6 +5422,20 @@ class ChatWindow(ChatWindowMixin, QWidget):
             result.extend(character for character in self._group_characters if character != priority_character)
         return result[:6]
 
+    def _is_active_reply_stream(self, stream: ReplyStreamBinding | None) -> bool:
+        return is_active_reply_stream(
+            stream,
+            self._active_reply_stream,
+            self._worker,
+            self._current_bubble,
+        )
+
+    def _clear_active_reply_stream(self, stream: ReplyStreamBinding | None = None):
+        if stream is not None and stream is not self._active_reply_stream:
+            return
+        self._active_reply_stream = None
+        self._stream_buffer_owner = None
+
     def _start_response_for_character(self, character: str, spoken_names: list[str]):
         self._set_busy(True, planning=False)
         api_url = self._cfg.get("llm_api_url", "")
@@ -5446,6 +5465,14 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._msg_layout.insertWidget(self._msg_layout.count() - 1, self._current_bubble)
         self._relayout_message_bubbles()
         self._scroll_to_bottom_for_stream()
+        self._reply_stream_generation += 1
+        reply_stream = ReplyStreamBinding(
+            self._reply_stream_generation,
+            character,
+            self._current_bubble,
+        )
+        self._active_reply_stream = reply_stream
+        self._stream_buffer_owner = reply_stream
 
         messages = self._build_messages_for_character(character, spoken_names)
         self._pending_interaction_context = ""
@@ -5486,12 +5513,24 @@ class ChatWindow(ChatWindowMixin, QWidget):
                 show_search_sources=show_search_sources,
                 tool_config=tool_config,
             )
-        self._worker.chunk_received.connect(self._on_chunk_received)
-        if hasattr(self._worker, "auto_continue_boundary"):
-            self._worker.auto_continue_boundary.connect(self._on_auto_continue_boundary)
-        self._worker.finished.connect(self._on_response_finished)
-        self._worker.error.connect(self._on_response_error)
-        self._worker.start()
+        worker = self._worker
+        reply_stream.worker = worker
+        worker.chunk_received.connect(
+            lambda text, reasoning, stream=reply_stream: self._on_chunk_received(stream, text, reasoning)
+        )
+        if hasattr(worker, "auto_continue_boundary"):
+            worker.auto_continue_boundary.connect(
+                lambda full_text, reasoning_text, actions, stream=reply_stream:
+                self._on_auto_continue_boundary(stream, full_text, reasoning_text, actions)
+            )
+        worker.finished.connect(
+            lambda full_text, reasoning_text, actions, stream=reply_stream:
+            self._on_response_finished(stream, full_text, reasoning_text, actions)
+        )
+        worker.error.connect(
+            lambda error_msg, stream=reply_stream: self._on_response_error(stream, error_msg)
+        )
+        worker.start()
 
     def _start_next_group_response(self):
         if not self._group_queue:
@@ -5515,15 +5554,14 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._reasoning_stream_text = ""
         self._start_response_for_character(character, list(self._group_spoken))
 
-    def _on_chunk_received(self, text: str, reasoning: str):
-        if self.sender() is not self._worker:
+    def _on_chunk_received(self, stream: ReplyStreamBinding, text: str, reasoning: str):
+        if not self._is_active_reply_stream(stream):
             return
         if reasoning:
             self._reasoning_stream_text += reasoning
-            if self._current_bubble:
-                self._current_bubble.set_reasoning(self._reasoning_stream_text)
-                self._current_bubble.set_streaming(True)
-                self._scroll_to_bottom_for_stream()
+            stream.bubble.set_reasoning(self._reasoning_stream_text)
+            stream.bubble.set_streaming(True)
+            self._scroll_to_bottom_for_stream()
 
         text = self._extract_stream_search_sources(text)
         chunk_actions, self._action_tag_stream_buffer = consume_stream_action_tags(
@@ -5541,18 +5579,19 @@ class ChatWindow(ChatWindowMixin, QWidget):
                 self._visible_stream_text + self._stream_buffer + tts_clean,
                 self._current_response_actions,
             )
-            self._enqueue_tts_text(tts_clean, self._active_response_character)
+            self._enqueue_tts_text(tts_clean, stream.character)
 
         clean = strip_action_tags(text)
         if clean:
             self._stream_buffer += clean
-            if self._current_bubble:
-                self._current_bubble.set_streaming(True)
+            self._stream_buffer_owner = stream
+            stream.bubble.set_streaming(True)
             if not self._stream_flush_timer.isActive():
                 self._stream_flush_timer.start()
 
     def _flush_stream_text(self):
-        if not self._current_bubble:
+        stream = self._stream_buffer_owner
+        if not self._is_active_reply_stream(stream):
             self._stream_flush_timer.stop()
             self._stream_buffer = ""
             return
@@ -5563,17 +5602,24 @@ class ChatWindow(ChatWindowMixin, QWidget):
         take = max(1, min(4, len(self._stream_buffer)))
         self._visible_stream_text += self._stream_buffer[:take]
         self._stream_buffer = self._stream_buffer[take:]
-        self._current_bubble.set_text(self._visible_stream_text)
+        stream.bubble.set_text(self._visible_stream_text)
         self._scroll_to_bottom_for_stream()
 
-    def _on_auto_continue_boundary(self, full_text: str, reasoning_text: str, actions: list):
-        if self.sender() is not self._worker:
+    def _on_auto_continue_boundary(
+        self,
+        stream: ReplyStreamBinding,
+        full_text: str,
+        reasoning_text: str,
+        actions: list,
+    ):
+        if not self._is_active_reply_stream(stream):
             return
-        self._finalize_current_response_segment(full_text, reasoning_text, actions)
-        self._start_auto_continue_bubble(self._active_response_character)
+        self._finalize_current_response_segment(stream, full_text, reasoning_text, actions)
+        self._start_auto_continue_bubble(stream)
 
     def _finalize_current_response_segment(
         self,
+        stream: ReplyStreamBinding,
         full_text: str,
         reasoning_text: str,
         actions: list,
@@ -5587,42 +5633,42 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._action_tag_stream_buffer = ""
         behavior = infer_emotion_behavior(full_text, acts)
         if behavior and (not self._cfg or self._cfg.get("emotion_behavior_enabled", True)):
-            publish_emotion_behavior(self._active_response_character, behavior)
+            publish_emotion_behavior(stream.character, behavior)
         self._current_tts_rate = emotion_tts_rate(full_text, acts)
-        self._pending_action_character = self._active_response_character
+        self._pending_action_character = stream.character
         self._pending_actions.extend(acts)
         self._flush_actions()
 
         clean, inline_sources = extract_inline_search_sources(full_text)
         self._merge_search_sources(inline_sources)
         clean = strip_action_tags(clean)
-        clean = self._sanitize_group_assistant_reply(self._active_response_character, clean)
+        clean = self._sanitize_group_assistant_reply(stream.character, clean)
         clean, text_poke_user = self._consume_poke_user_stage_directions(
             clean,
-            self._active_response_character,
+            stream.character,
         )
         if text_poke_user:
             try:
                 publish_user_poke(
-                    self._active_response_character,
+                    stream.character,
                     source="assistant_text",
                     direction="to_user",
                 )
             except Exception:
                 pass
         reasoning_clean = strip_action_tags(reasoning_text)
-        self._flush_tts_text(self._active_response_character)
-        if self._current_bubble:
+        self._flush_tts_text(stream.character, stream.bubble)
+        if self._is_active_reply_stream(stream):
             self._stream_flush_timer.stop()
             self._stream_buffer = ""
             self._visible_stream_text = clean
             self._reasoning_stream_text = reasoning_clean
-            self._current_bubble.set_streaming(False)
-            self._current_bubble.set_reasoning(reasoning_clean)
-            self._current_bubble.set_search_sources(self._stream_search_sources if self._show_search_sources() else [])
-            self._current_bubble.set_text(clean)
+            stream.bubble.set_streaming(False)
+            stream.bubble.set_reasoning(reasoning_clean)
+            stream.bubble.set_search_sources(self._stream_search_sources if self._show_search_sources() else [])
+            stream.bubble.set_text(clean)
 
-        stored = self._assistant_content(self._active_response_character, clean)
+        stored = self._assistant_content(stream.character, clean)
         tool_trace = {}
         if self._stream_search_sources:
             tool_trace["web_search_sources"] = self._stream_search_sources
@@ -5635,10 +5681,11 @@ class ChatWindow(ChatWindowMixin, QWidget):
         elif self._conv_id:
             self._db.add_message(self._conv_id, "assistant", stored, reasoning_clean, tool_trace=tool_trace)
             self._refresh_group_list()
-        self._apply_relationship_update(self._active_response_character, self._last_user_text, clean, acts)
+        self._apply_relationship_update(stream.character, self._last_user_text, clean, acts)
         return clean
 
-    def _start_auto_continue_bubble(self, character: str):
+    def _start_auto_continue_bubble(self, stream: ReplyStreamBinding):
+        character = stream.character
         self._stream_buffer = ""
         self._visible_stream_text = ""
         self._reasoning_stream_text = ""
@@ -5663,12 +5710,21 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._msg_layout.insertWidget(self._msg_layout.count() - 1, self._current_bubble)
         self._relayout_message_bubbles()
         self._scroll_to_bottom_for_stream()
+        stream.bubble = self._current_bubble
+        self._stream_buffer_owner = stream
 
-    def _on_response_finished(self, full_text: str, reasoning_text: str, actions: list):
-        if self.sender() is not self._worker:
+    def _on_response_finished(
+        self,
+        stream: ReplyStreamBinding,
+        full_text: str,
+        reasoning_text: str,
+        actions: list,
+    ):
+        if not self._is_active_reply_stream(stream):
             return
-        usage = getattr(self._worker, "token_usage", None)
+        usage = getattr(stream.worker, "token_usage", None)
         self._finalize_current_response_segment(
+            stream,
             full_text,
             reasoning_text,
             actions,
@@ -5676,8 +5732,9 @@ class ChatWindow(ChatWindowMixin, QWidget):
         )
 
         if self._is_group_chat:
-            self._group_spoken.append(self._model_manager.get_display_name(self._active_response_character))
+            self._group_spoken.append(self._model_manager.get_display_name(stream.character))
             self._worker = None
+            self._clear_active_reply_stream(stream)
             self._current_bubble = None
             if self._auto_active:
                 QTimer.singleShot(self._auto_delay_ms, self._start_next_group_response)
@@ -5689,15 +5746,15 @@ class ChatWindow(ChatWindowMixin, QWidget):
             self._input.setFocus()
             self._sync_input_height()
             self._worker = None
+            self._clear_active_reply_stream(stream)
             self._current_bubble = None
             self._scroll_to_bottom_for_stream()
 
-    def _on_response_error(self, error_msg: str):
-        if self.sender() is not self._worker:
+    def _on_response_error(self, stream: ReplyStreamBinding, error_msg: str):
+        if not self._is_active_reply_stream(stream):
             return
-        if self._current_bubble:
-            self._current_bubble.set_streaming(False)
-            self._current_bubble.set_text(format_llm_error_message(error_msg))
+        stream.bubble.set_streaming(False)
+        stream.bubble.set_text(format_llm_error_message(error_msg))
         self._stream_flush_timer.stop()
         self._stream_buffer = ""
         self._action_tag_stream_buffer = ""
@@ -5712,6 +5769,7 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._input.setFocus()
         self._sync_input_height()
         self._worker = None
+        self._clear_active_reply_stream(stream)
         self._current_bubble = None
 
     def _flush_actions(self):
@@ -5764,7 +5822,7 @@ class ChatWindow(ChatWindowMixin, QWidget):
         self._tts_request_allowed = True
         self._tts_text_buffer += text
 
-    def _flush_tts_text(self, character: str):
+    def _flush_tts_text(self, character: str, bubble: MessageBubble | None = None):
         if not self._tts_enabled() or not self._tts_request_allowed:
             return
         self._tts_tag_buffer = ""
@@ -5773,8 +5831,9 @@ class ChatWindow(ChatWindowMixin, QWidget):
         if text:
             sequence = self._tts_next_sequence
             self._tts_next_sequence += 1
-            if self._current_bubble:
-                self._tts_bubbles[sequence] = self._current_bubble
+            target_bubble = bubble or self._current_bubble
+            if target_bubble:
+                self._tts_bubbles[sequence] = target_bubble
             self._tts_characters[sequence] = character
             self._queue_tts_request(sequence, text, character)
         self._start_next_tts_request()

--- a/reply_stream.py
+++ b/reply_stream.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ReplyStreamBinding:
+    """Owns the UI target for one LLM response stream."""
+
+    generation: int
+    character: str
+    bubble: object
+    worker: object | None = None
+
+
+def is_active_reply_stream(
+    stream: ReplyStreamBinding | None,
+    active_stream: ReplyStreamBinding | None,
+    worker: object | None,
+    bubble: object | None,
+) -> bool:
+    """Return whether a callback still owns the active response UI."""
+
+    return bool(
+        stream is not None
+        and stream is active_stream
+        and stream.worker is worker
+        and stream.bubble is bubble
+    )

--- a/tests/test_group_reply_stream_binding.py
+++ b/tests/test_group_reply_stream_binding.py
@@ -1,0 +1,29 @@
+import unittest
+
+from reply_stream import ReplyStreamBinding, is_active_reply_stream
+
+
+class GroupReplyStreamBindingTests(unittest.TestCase):
+    @staticmethod
+    def _stream(generation, character):
+        stream = ReplyStreamBinding(generation, character, object())
+        stream.worker = object()
+        return stream
+
+    def test_late_chunk_cannot_write_into_the_next_characters_bubble(self):
+        first = self._stream(1, "character-a")
+        second = self._stream(2, "character-b")
+
+        self.assertTrue(is_active_reply_stream(first, first, first.worker, first.bubble))
+        self.assertFalse(is_active_reply_stream(first, second, second.worker, second.bubble))
+
+    def test_old_flush_timer_cannot_append_into_the_next_characters_bubble(self):
+        first = self._stream(1, "character-a")
+        second = self._stream(2, "character-b")
+
+        self.assertFalse(is_active_reply_stream(first, second, second.worker, second.bubble))
+        self.assertTrue(is_active_reply_stream(second, second, second.worker, second.bubble))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
解决串行问题：将每次 LLM 流绑定到独立的角色、气泡和 worker；chunk、完成和错误回调只允许更新自己所属的气泡。旧请求的迟到回调和旧刷新定时器都会被丢弃，TTS 高亮也绑定到正确气泡。