### PR TITLE
修复 Moc3 零增量物理姿态回落

### DIFF
--- a/live2d_lua_adapter_moc3.py
+++ b/live2d_lua_adapter_moc3.py
@@ -112,9 +112,42 @@ def _patch_lua_moc3_pet_embed_delta(module_name: str, chunk: bytes) -> bytes:
     return chunk.replace(old_scale, new_scale, 1)
 
 
+def _patch_lua_moc3_physics_zero_delta(module_name: str, chunk: bytes) -> bytes:
+    if module_name != "live2d.cubism3.physics":
+        return chunk
+    chunk = chunk.replace(b"\r\n", b"\n")
+    old_guard = (
+        b"    delta = tonumber(delta) or 0\n"
+        b"    if delta <= 0 then return false end\n"
+    )
+    new_guard = (
+        b"    delta = tonumber(delta) or 0\n"
+        b"    self.last_substep_count = 0\n"
+        b"    if delta <= 0 then\n"
+        b"        local physics_delta = self.data.fps > 0 and 1.0 / self.data.fps or 1.0\n"
+        b"        self:_interpolate(runtime, self.remaining_time / physics_delta)\n"
+        b"        return false\n"
+        b"    end\n"
+    )
+    if old_guard not in chunk:
+        return chunk
+    chunk = chunk.replace(old_guard, new_guard, 1)
+    substep_marker = b"    while self.remaining_time >= physics_delta do\n"
+    return chunk.replace(
+        substep_marker,
+        substep_marker + b"        self.last_substep_count = self.last_substep_count + 1\n",
+        1,
+    )
+
+
+def _patch_lua_moc3_module(module_name: str, chunk: bytes) -> bytes:
+    chunk = _patch_lua_moc3_pet_embed_delta(module_name, chunk)
+    return _patch_lua_moc3_physics_zero_delta(module_name, chunk)
+
+
 class LuaLive2DModuleMOC3(LuaLive2DRuntimeBase):
     def _get_extra_module_patch(self):
-        return _patch_lua_moc3_pet_embed_delta
+        return _patch_lua_moc3_module
 
     def _ensure_runtime(self):
         if self._initialized:

--- a/tests/test_moc3_physics_timing.py
+++ b/tests/test_moc3_physics_timing.py
@@ -3,11 +3,23 @@ from pathlib import Path
 import pytest
 from lupa.luajit21 import LuaRuntime
 
+from live2d_lua_adapter_moc3 import _patch_lua_moc3_module
+
 
 def _physics_zero_delta_probe():
     lua = LuaRuntime(unpack_returned_tuples=True)
     lua.execute("jit.off()")
     root = (Path(__file__).resolve().parents[1] / "third_party" / "Live2D-v2-Lua").as_posix()
+    physics_path = Path(root) / "live2d" / "cubism3" / "physics.lua"
+    physics_source = _patch_lua_moc3_module(
+        "live2d.cubism3.physics", physics_path.read_bytes()
+    )
+    lua.globals()["__bandori_test_physics_source"] = physics_source
+    lua.execute(
+        "package.preload['live2d.cubism3.physics'] = function() "
+        "local fn = assert(load(__bandori_test_physics_source, '@physics.lua')); "
+        "return fn() end"
+    )
     lua.execute(
         "package.path = package.path .. ';' .. ... .. '/?.lua;' .. ... .. '/?/init.lua'",
         root,


### PR DESCRIPTION
## 修复内容

- 在加载 Moc3 物理模块时补充零时间增量处理。
- 不推进物理模拟，但重新应用上一帧的插值物理输出。
- 记录本次物理子步数，零增量时保持为 0。

## 根因与影响

渲染管线会在物理计算前恢复动作/基础参数。当同一时间戳触发重复渲染时，原实现因 `delta <= 0` 直接返回，未重新应用已计算的物理姿态，导致身体、头发等参数瞬间回落到基础值并产生抖动。

## 验证

- `python3 -m pytest -q tests`
- 结果：`445 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile live2d_lua_adapter_moc3.py tests/test_moc3_physics_timing.py`
- `git diff --check`
