### PR TITLE
修复本地服务令牌生成崩溃

### DIFF
--- a/local_port_security.py
+++ b/local_port_security.py
@@ -1,0 +1,20 @@
+import secrets
+
+
+def ensure_local_port_token(config, token_key: str) -> str:
+    """Return a configured token, generating and persisting one when absent.
+
+    Loopback HTTP endpoints still need authentication because another local
+    process or a web page can send plain requests to them.
+    """
+    token = str(config.get(token_key, "") or "").strip()
+    if token:
+        return token
+
+    token = secrets.token_urlsafe(18)
+    config.set(token_key, token)
+    try:
+        config.save()
+    except Exception as exc:
+        print(f"Failed to persist generated {token_key}: {exc}")
+    return token

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from process_utils import (
 )
 from startup_manager import repair_startup_command
 from app_info import APP_NAME
+from local_port_security import ensure_local_port_token
 
 BASE_DIR, _STARTUP_CONFIG = bootstrap_app()
 from config_manager import DEFAULTS
@@ -437,24 +438,6 @@ def main():
             server.stop()
         chat_integration_ref["server"] = None
 
-    def ensure_local_port_token(token_key: str) -> str:
-        # A loopback HTTP port with no token accepts unauthenticated requests
-        # from any local process or web page (CORS does not block plain POSTs),
-        # which could inject fake chat/AI events into the pet. When such a port
-        # is enabled without a token, mint and persist one so the running server
-        # is always authenticated. cfg.save() merges with disk, so this never
-        # clobbers other settings.
-        token = str(cfg.get(token_key, "") or "").strip()
-        if token:
-            return token
-        token = secrets.token_urlsafe(18)
-        cfg.set(token_key, token)
-        try:
-            cfg.save()
-        except Exception as exc:
-            print(f"Failed to persist generated {token_key}: {exc}")
-        return token
-
     def close_chat_integration_db():
         db = chat_integration_ref.get("db")
         if db is not None:
@@ -466,7 +449,7 @@ def main():
         if not cfg.get("ai_status_port_enabled", False):
             return
         port = clamp_int(cfg.get("ai_status_port", 38472), 1024, 65535, 38472)
-        token = ensure_local_port_token("ai_status_token")
+        token = ensure_local_port_token(cfg, "ai_status_token")
 
         def on_ai_event(event: dict):
             payload = json.dumps(event, ensure_ascii=False)
@@ -556,7 +539,7 @@ def main():
         if not cfg.get("chat_integration_enabled", False):
             return
         port = clamp_int(cfg.get("chat_integration_port", 38473), 1024, 65535, 38473)
-        token = ensure_local_port_token("chat_integration_token")
+        token = ensure_local_port_token(cfg, "chat_integration_token")
         try:
             server = ChatIntegrationHttpServer(
                 port,

--- a/tests/test_local_http_server_lifecycle.py
+++ b/tests/test_local_http_server_lifecycle.py
@@ -2,12 +2,38 @@ import json
 import urllib.error
 import urllib.request
 from pathlib import Path
+from unittest.mock import Mock, patch
+
+from local_port_security import ensure_local_port_token
 
 
 def test_local_http_request_threads_do_not_block_server_close():
     from local_http_server import LocalThreadingHTTPServer
 
     assert LocalThreadingHTTPServer.daemon_threads is True
+
+
+def test_missing_local_port_token_is_generated_and_persisted():
+    config = Mock()
+    config.get.return_value = ""
+
+    with patch("local_port_security.secrets.token_urlsafe", return_value="generated-token"):
+        token = ensure_local_port_token(config, "chat_integration_token")
+
+    assert token == "generated-token"
+    config.set.assert_called_once_with("chat_integration_token", "generated-token")
+    config.save.assert_called_once_with()
+
+
+def test_existing_local_port_token_is_reused():
+    config = Mock()
+    config.get.return_value = " existing-token "
+
+    token = ensure_local_port_token(config, "ai_status_token")
+
+    assert token == "existing-token"
+    config.set.assert_not_called()
+    config.save.assert_not_called()
 
 
 def test_local_http_request_body_reads_have_a_timeout():


### PR DESCRIPTION
## 修复内容

- 将本地 HTTP 服务的 token 生成与持久化提取为可测试的辅助函数。
- AI 状态端口和聊天集成端口统一调用该函数。
- 增加空 token 生成与已有 token 复用的回归测试。

## 根因与影响

`main.py` 的空 token 启动路径调用了 `secrets.token_urlsafe()`，但没有导入 `secrets`。用户启用 AI 状态端口或聊天集成端口且尚未配置 token 时，会触发 `NameError`，导致本地服务无法启动。

## 验证

- `python3 -m pytest -q tests`
- 结果：`447 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile main.py local_port_security.py tests/test_local_http_server_lifecycle.py`
- Pyflakes 已确认本次 `secrets` 未定义错误消失。
- `git diff --check`
