### PR TITLE
修复聊天窗口戳一戳动画崩溃

### DIFF
--- a/chat_window/chat_window.py
+++ b/chat_window/chat_window.py
@@ -5,7 +5,7 @@ fluent_bootstrap.prefer_local_pyside6_fluent_widgets()
 import logging
 import time
 
-from PySide6.QtCore import Qt, Signal, QTimer, QPropertyAnimation, QEasingCurve, QEvent, QRect, QSize, QVariantAnimation, QParallelAnimationGroup
+from PySide6.QtCore import Qt, Signal, QTimer, QPropertyAnimation, QEasingCurve, QEvent, QPoint, QRect, QSize, QVariantAnimation, QParallelAnimationGroup
 from PySide6.QtGui import QFont, QColor, QPalette, QIcon, QKeyEvent, QPainter, QPainterPath, QPen, QPixmap, QImage, QImageReader, QTextCursor
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,

--- a/tests/test_poke_user_feedback.py
+++ b/tests/test_poke_user_feedback.py
@@ -1,3 +1,7 @@
+from unittest.mock import patch
+
+from PySide6.QtCore import QPoint
+
 from pet_window import (
     POKE_USER_BADGE_DURATION_MS,
     POKE_USER_WINDOW_SHAKE_INTENSITY,
@@ -46,6 +50,58 @@ class _ChatPokeHarness:
         self.calls.append(("send", character))
 
 
+class _SignalHarness:
+    def __init__(self):
+        self.callback = None
+
+    def connect(self, callback):
+        self.callback = callback
+
+
+class _AnimationHarness:
+    def __init__(self, parent):
+        self.parent = parent
+        self.valueChanged = _SignalHarness()
+        self.finished = _SignalHarness()
+        self.key_values = []
+        self.started = False
+
+    def setDuration(self, duration):
+        self.duration = duration
+
+    def setEasingCurve(self, curve):
+        self.curve = curve
+
+    def setKeyValueAt(self, step, value):
+        self.key_values.append((step, value))
+
+    def start(self):
+        self.started = True
+
+
+class _ShakeHarness:
+    _play_poke_window_shake = ChatWindow._play_poke_window_shake
+
+    def __init__(self):
+        self._closing = False
+        self._close_animating = False
+        self._poke_window_anim = None
+        self._poke_window_anim_origin = None
+        self.moves = []
+
+    def isVisible(self):
+        return True
+
+    def isMinimized(self):
+        return False
+
+    def pos(self):
+        return QPoint(120, 80)
+
+    def move(self, point):
+        self.moves.append(QPoint(point))
+
+
 def test_model_poke_shows_extended_badge_and_subtle_window_shake():
     harness = _PokeHarness()
     event = {
@@ -89,6 +145,20 @@ def test_model_poke_shakes_matching_chat_window_without_sending_again():
     assert _POKE_WINDOW_SHAKE_DURATION_MS == 360
     assert _POKE_WINDOW_SHAKE_AMPLITUDE == 8
     assert harness.calls == [("window_shake",)]
+
+
+def test_chat_poke_shake_builds_and_starts_position_animation():
+    harness = _ShakeHarness()
+
+    with patch("chat_window.chat_window.QVariantAnimation", _AnimationHarness):
+        harness._play_poke_window_shake()
+
+    animation = harness._poke_window_anim
+    assert animation.started is True
+    assert animation.duration == _POKE_WINDOW_SHAKE_DURATION_MS
+    assert animation.key_values[0] == (0.0, QPoint(120, 80))
+    assert animation.key_values[-1] == (1.0, QPoint(120, 80))
+    assert harness._poke_window_anim_origin == QPoint(120, 80)
 
 
 def test_model_poke_does_not_shake_unrelated_chat_window():


### PR DESCRIPTION
## 修复内容

- 为聊天窗口补充 `QPoint` 导入。
- 增加戳一戳窗口摇动动画的直接回归测试，验证位置关键帧和动画启动。

## 根因与影响

聊天窗口收到角色对用户的戳一戳事件后会执行摇动动画。该路径使用 `QPoint` 创建和判断窗口位置，但模块未导入 `QPoint`，因此首次触发时抛出 `NameError`，动画和后续反馈中断。

## 验证

- `python3 -m pytest -q tests`
- 结果：`448 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile chat_window/chat_window.py tests/test_poke_user_feedback.py`
- Pyflakes 不再报告 `QPoint` 未定义。
- `git diff --check`
