### PR TITLE
修复 MCP Content-Length 大小写兼容

### DIFF
--- a/mcp_base.py
+++ b/mcp_base.py
@@ -24,7 +24,7 @@ def extract_message_from_buffer(buffer: bytes) -> tuple[str | None, bytes]:
     buffer = buffer.lstrip(b"\r\n")
     if not buffer:
         return None, buffer
-    if buffer.startswith(b"Content-Length:"):
+    if buffer[:15].lower() == b"content-length:":
         header_end = buffer.find(b"\r\n\r\n")
         if header_end < 0:
             return None, buffer

--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -793,7 +793,7 @@ def _extract_stdio_message(buffer: bytes) -> tuple[dict | None, bytes]:
     buffer = buffer.lstrip(b"\r\n")
     if not buffer:
         return None, buffer
-    if buffer.startswith(b"Content-Length:"):
+    if buffer[:15].lower() == b"content-length:":
         header_end = buffer.find(b"\r\n\r\n")
         if header_end < 0:
             return None, buffer

--- a/tests/test_mcp_cancellation.py
+++ b/tests/test_mcp_cancellation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import mcp_bridge
+from mcp_base import extract_message_from_buffer
 
 
 class McpCancellationTests(unittest.TestCase):
@@ -65,6 +66,21 @@ class McpCancellationTests(unittest.TestCase):
         payload = stdin.getvalue()
         self.assertNotIn(b"Content-Length:", payload)
         self.assertTrue(payload.endswith(b"\n"))
+
+    def test_content_length_header_name_is_case_insensitive(self):
+        payload = b'{"jsonrpc":"2.0","id":7,"result":{}}'
+        framed = (
+            b"content-length: " + str(len(payload)).encode("ascii")
+            + b"\r\n\r\n" + payload
+        )
+
+        server_message, server_remaining = extract_message_from_buffer(framed)
+        client_message, client_remaining = mcp_bridge._extract_stdio_message(framed)
+
+        self.assertEqual(payload.decode("utf-8"), server_message)
+        self.assertEqual(b"", server_remaining)
+        self.assertEqual({"jsonrpc": "2.0", "id": 7, "result": {}}, client_message)
+        self.assertEqual(b"", client_remaining)
 
     def test_stdio_close_terminates_process_before_closing_stdout(self):
         events = []


### PR DESCRIPTION
## 修复内容

- MCP 客户端与内置服务端的 stdio 帧解析器以大小写无关方式识别 `Content-Length`。
- 增加小写 `content-length` 帧的双向回归测试。

## 根因与影响

头字段名应按大小写无关方式处理，但原解析器只接受精确的 `Content-Length:`。使用 `content-length:` 等合法变体的 MCP 实现会被误判为 JSONL，导致消息被丢弃、响应超时或连接关闭。

## 验证

- `python3 -m pytest -q tests`
- 结果：`449 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile mcp_base.py mcp_bridge.py tests/test_mcp_cancellation.py`
- `git diff --check`
