### PR TITLE
修复 OneBot @账号前缀误匹配

### DIFF
--- a/onebot_message.py
+++ b/onebot_message.py
@@ -159,6 +159,10 @@ def onebot_event_mentions_self(event: dict) -> bool:
             if str(data.get("qq") or "").strip() == self_id:
                 return True
     raw_message = str(event.get("raw_message") or "")
-    if raw_message and f"[CQ:at,qq={self_id}" in raw_message:
+    if raw_message and re.search(
+        rf"\[CQ:at,qq={re.escape(self_id)}(?:,|\])",
+        raw_message,
+        flags=re.IGNORECASE,
+    ):
         return True
     return False

--- a/tests/test_napcat_delivery_semantics.py
+++ b/tests/test_napcat_delivery_semantics.py
@@ -5,9 +5,26 @@ from unittest.mock import Mock
 from PySide6.QtCore import QUrlQuery
 
 from napcat_adapter import NapcatClient
+from onebot_message import onebot_event_mentions_self
 
 
 class NapcatDeliverySemanticsTest(unittest.TestCase):
+    def test_raw_cq_mention_does_not_match_account_id_prefix(self):
+        event = {
+            "self_id": 123,
+            "raw_message": "[CQ:at,qq=1234] 这条消息不是发给机器人",
+        }
+
+        self.assertFalse(onebot_event_mentions_self(event))
+
+    def test_raw_cq_mention_accepts_exact_id_with_extra_parameters(self):
+        event = {
+            "self_id": 123,
+            "raw_message": "[CQ:at,qq=123,name=BandoriPet] 你好",
+        }
+
+        self.assertTrue(onebot_event_mentions_self(event))
+
     def test_main_does_not_auto_reply_to_duplicate_saved_messages(self):
         from pathlib import Path
 


### PR DESCRIPTION
## 修复内容

- OneBot 原始 CQ 消息中的 @账号判断改为带参数边界的精确匹配。
- 保留 CQ 代码大小写兼容和 `name` 等附加参数支持。
- 增加账号前缀冲突回归测试。

## 根因与影响

原逻辑用字符串前缀搜索 `[CQ:at,qq={self_id}`。机器人账号 `123` 会错误匹配实际目标 `1234`，使机器人在群聊中处理并回复本不属于自己的消息。

## 验证

- `python3 -m pytest -q tests`
- 结果：`451 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile onebot_message.py tests/test_napcat_delivery_semantics.py`
- `git diff --check`
