### PR TITLE
修复孤立推理闭合标签内容泄漏

### DIFF
--- a/llm_thinking.py
+++ b/llm_thinking.py
@@ -49,5 +49,13 @@ def split_thinking_text(content: str, reasoning: str = "") -> tuple[str, str]:
         if text:
             collected.append(text)
         clean = clean[:unclosed.start()]
-    clean = _CLOSE_REASONING_TAG_PATTERN.sub("", clean).strip()
+    while True:
+        orphan_close = _CLOSE_REASONING_TAG_PATTERN.search(clean)
+        if orphan_close is None:
+            break
+        text = clean[:orphan_close.start()].strip()
+        if text:
+            collected.append(text)
+        clean = clean[orphan_close.end():]
+    clean = clean.strip()
     return clean, "\n\n".join(collected).strip()

--- a/tests/test_reasoning_text.py
+++ b/tests/test_reasoning_text.py
@@ -30,6 +30,25 @@ def test_unclosed_reasoning_tail_is_never_exposed_as_visible_text():
     assert "未闭合的内部推理" in reasoning
 
 
+def test_orphan_reasoning_close_tag_hides_preceding_internal_text():
+    visible, reasoning = split_thinking_text(
+        "内部推理内容</thinking>[smile]这是给用户的回答。"
+    )
+
+    assert visible == "[smile]这是给用户的回答。"
+    assert reasoning == "内部推理内容"
+
+
+def test_orphan_reasoning_close_tag_preserves_existing_reasoning():
+    visible, reasoning = split_thinking_text(
+        "补充内部推理</ANALYSIS>继续加油。",
+        "接口独立推理",
+    )
+
+    assert visible == "继续加油。"
+    assert reasoning == "接口独立推理\n\n补充内部推理"
+
+
 def test_aux_vision_uses_the_same_reasoning_filter():
     assert _strip_thinking_text(
         "<thinking>识别截图细节</thinking>用户正在编辑代码。"


### PR DESCRIPTION
## 修复内容

- 将没有对应起始标签的 `</think>`、`</thinking>`、`</reasoning>`、`</analysis>` 视为推理区段终点。
- 闭合标签之前的内容归入 reasoning，仅保留标签之后的用户可见回答。
- 增加孤立闭合标签与既有 reasoning 合并的回归测试。

## 根因与影响

部分兼容模型可能只在正文中返回推理闭合标签。原过滤器会直接删除该标签，却把标签前的内部推理和标签后的答案拼接成可见文本，导致推理内容进入聊天、辅助视觉结果或系统提醒。

## 验证

- `python3 -m pytest -q tests`
- 结果：`453 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile llm_thinking.py tests/test_reasoning_text.py`
- `git diff --check`
