### PR TITLE
修复 TTS 翻译朗读内部推理

### DIFF
--- a/tests/test_model_request_headers.py
+++ b/tests/test_model_request_headers.py
@@ -59,3 +59,25 @@ def test_aux_translation_request_uses_compatible_user_agent():
 
     assert result == "translation"
     assert requests[0][0].get_header("User-agent") == OPENAI_COMPAT_USER_AGENT
+
+
+def test_aux_translation_removes_reasoning_before_tts():
+    response = io.BytesIO(json.dumps({
+        "choices": [{
+            "message": {
+                "content": "<thinking>先分析语气</thinking>Hello!",
+                "reasoning_content": "hidden reasoning",
+            },
+        }],
+    }).encode("utf-8"))
+    config = {
+        "llm_aux_api_url": "https://example.com/v1",
+        "llm_aux_api_key": "secret",
+        "llm_aux_model_id": "translation-model",
+        "llm_aux_enable_thinking": True,
+    }
+
+    with patch("tts_manager.urllib.request.urlopen", return_value=response):
+        result = _translate_to_selected_language(config, "你好", "English")
+
+    assert result == "Hello!"

--- a/tts_manager.py
+++ b/tts_manager.py
@@ -15,6 +15,7 @@ from llm_api_compat import (
     openai_compat_headers,
     sanitize_chat_body_for_url,
 )
+from llm_thinking import split_thinking_text
 from process_utils import app_base_dir
 from tts_common import strip_tts_action_tags
 
@@ -223,7 +224,20 @@ def _translate_to_selected_language(config: dict, text: str, target_language: st
     choices = data.get("choices", [])
     if not choices:
         return ""
-    return choices[0].get("message", {}).get("content", "").strip()
+    message = choices[0].get("message", {})
+    reasoning = next(
+        (
+            message.get(key)
+            for key in ("reasoning_content", "reasoning", "thinking")
+            if isinstance(message.get(key), str) and message.get(key)
+        ),
+        "",
+    )
+    translated, _reasoning = split_thinking_text(
+        message.get("content", ""),
+        reasoning,
+    )
+    return translated
 
 
 _VISEME_POSES = {


### PR DESCRIPTION
## 修复内容

- TTS 辅助翻译复用统一的推理文本过滤器。
- 识别 `reasoning_content`、`reasoning`、`thinking` 独立字段。
- 过滤翻译正文中的 `<think>`、`<thinking>`、`<reasoning>`、`<analysis>` 内容。
- 增加推理开启情况下的翻译回归测试。

## 根因与影响

辅助翻译允许启用模型 thinking，但原实现直接将 `message.content` 交给 TTS。兼容模型若把内部推理标签放进正文，这些内容会被当成译文送往语音后端并朗读。

## 验证

- `python3 -m pytest -q tests`
- 结果：`454 passed, 1 skipped, 72 subtests passed`
- `python3 -m py_compile tts_manager.py tests/test_model_request_headers.py`
- `git diff --check`
