### PR TITLE
修复 TTS 翻译朗读动作标签

### DIFF
--- a/tests/test_model_request_headers.py
+++ b/tests/test_model_request_headers.py
@@ -81,3 +81,17 @@ def test_aux_translation_removes_reasoning_before_tts():
         result = _translate_to_selected_language(config, "你好", "English")
 
     assert result == "Hello!"
+
+
+def test_aux_translation_removes_generated_action_tags_before_tts():
+    response = _json_response("[smile][mtn_wave]Hello!")
+    config = {
+        "llm_aux_api_url": "https://example.com/v1",
+        "llm_aux_api_key": "secret",
+        "llm_aux_model_id": "translation-model",
+    }
+
+    with patch("tts_manager.urllib.request.urlopen", return_value=response):
+        result = _translate_to_selected_language(config, "你好", "English")
+
+    assert result == "Hello!"

--- a/tts_manager.py
+++ b/tts_manager.py
@@ -237,7 +237,7 @@ def _translate_to_selected_language(config: dict, text: str, target_language: st
         message.get("content", ""),
         reasoning,
     )
-    return translated
+    return strip_tts_action_tags(translated)
 
 
 _VISEME_POSES = {


### PR DESCRIPTION
## 修复内容
- 在辅助翻译结果进入 TTS 前再次清除动作/运动标签。
- 增加辅助模型重新生成 `[smile]`、`[mtn_wave]` 时的回归测试。

## 根因与影响
原始聊天文本会在翻译前清除动作标签，但辅助模型可能在译文中重新生成标签。原实现直接把译文交给 TTS，导致标签名称被当成台词朗读。

## 验证
- `python3 -m pytest -q tests`
- 结果：455 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile tts_manager.py tests/test_model_request_headers.py`
- `git diff --check`
