### PR TITLE
限制自定义模型删除路径

### DIFF
--- a/custom_model_import.py
+++ b/custom_model_import.py
@@ -67,14 +67,27 @@ def sanitize_costume_id(costume_id: str, fallback: str = "default") -> str:
     return cleaned or fallback
 
 
+def _custom_character_dir(character: str) -> Path | None:
+    raw = str(character or "")
+    if not raw or Path(raw).name != raw or PureWindowsPath(raw).name != raw:
+        return None
+    try:
+        models_root = MODELS_DIR.resolve()
+        target = (MODELS_DIR / raw).resolve()
+    except (OSError, RuntimeError):
+        return None
+    return target if target.parent == models_root else None
+
+
 def is_custom_character(character: str) -> bool:
-    return (MODELS_DIR / character / CUSTOM_MARKER_FILENAME).is_file()
+    target = _custom_character_dir(character)
+    return bool(target and (target / CUSTOM_MARKER_FILENAME).is_file())
 
 
 def delete_custom_character(character: str) -> None:
     """Delete an imported custom character. Refuses to touch built-ins."""
-    target = MODELS_DIR / character
-    if not is_custom_character(character):
+    target = _custom_character_dir(character)
+    if target is None or not (target / CUSTOM_MARKER_FILENAME).is_file():
         raise CustomModelImportError("not_custom")
     shutil.rmtree(target)
 

--- a/tests/test_custom_model_import.py
+++ b/tests/test_custom_model_import.py
@@ -51,6 +51,42 @@ def _write_model3(root: Path) -> None:
 
 
 class CustomModelImportTest(unittest.TestCase):
+    def test_delete_removes_marked_character_inside_models_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            models = Path(temp_dir) / "models"
+            character = models / "Custom Character"
+            character.mkdir(parents=True)
+            (character / custom_model_import.CUSTOM_MARKER_FILENAME).write_text(
+                "{}",
+                encoding="utf-8",
+            )
+
+            with patch.object(custom_model_import, "MODELS_DIR", models):
+                custom_model_import.delete_custom_character("Custom Character")
+
+            self.assertFalse(character.exists())
+
+    def test_delete_rejects_character_outside_models_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            models = root / "models"
+            outside = root / "outside"
+            models.mkdir()
+            outside.mkdir()
+            (outside / custom_model_import.CUSTOM_MARKER_FILENAME).write_text(
+                "{}",
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(custom_model_import, "MODELS_DIR", models),
+                self.assertRaises(CustomModelImportError) as raised,
+            ):
+                custom_model_import.delete_custom_character("../outside")
+
+            self.assertEqual("not_custom", raised.exception.code)
+            self.assertTrue(outside.is_dir())
+
     def test_import_accepts_normal_relative_resources(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## 修复内容
- 自定义模型识别和删除前验证角色目录解析后仍为模型根目录的直接子目录。
- 拒绝 `../`、绝对路径、跨平台分隔符及符号链接逃逸路径。
- 增加合法删除与越界删除的回归测试。

## 根因与影响
删除逻辑此前直接拼接 `MODELS_DIR / character`，只要目标目录中存在 `_custom.json` 就会递归删除。传入 `../outside` 时可越过模型根目录并删除外部目录。

## 验证
- `python3 -m pytest -q tests/test_custom_model_import.py`
- 结果：6 passed
- `python3 -m pytest -q tests`
- 结果：457 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile custom_model_import.py tests/test_custom_model_import.py`
- `git diff --check`
