### PR TITLE
兼容 OneBot 提及参数顺序

### DIFF
--- a/onebot_message.py
+++ b/onebot_message.py
@@ -159,10 +159,12 @@ def onebot_event_mentions_self(event: dict) -> bool:
             if str(data.get("qq") or "").strip() == self_id:
                 return True
     raw_message = str(event.get("raw_message") or "")
-    if raw_message and re.search(
-        rf"\[CQ:at,qq={re.escape(self_id)}(?:,|\])",
-        raw_message,
-        flags=re.IGNORECASE,
-    ):
-        return True
+    if raw_message:
+        for match in re.finditer(r"\[CQ:at,([^\]]*)\]", raw_message, flags=re.IGNORECASE):
+            if re.search(
+                rf"(?:^|,)qq={re.escape(self_id)}(?:,|$)",
+                match.group(1),
+                flags=re.IGNORECASE,
+            ):
+                return True
     return False

--- a/tests/test_napcat_delivery_semantics.py
+++ b/tests/test_napcat_delivery_semantics.py
@@ -25,6 +25,14 @@ class NapcatDeliverySemanticsTest(unittest.TestCase):
 
         self.assertTrue(onebot_event_mentions_self(event))
 
+    def test_raw_cq_mention_accepts_qq_after_other_parameters(self):
+        event = {
+            "self_id": 123,
+            "raw_message": "[CQ:at,name=BandoriPet,qq=123] 你好",
+        }
+
+        self.assertTrue(onebot_event_mentions_self(event))
+
     def test_main_does_not_auto_reply_to_duplicate_saved_messages(self):
         from pathlib import Path
 


### PR DESCRIPTION
## 修复内容
- 在每个原始 `[CQ:at,...]` 段内按完整参数边界查找机器人 `qq`。
- 允许 `qq` 出现在 `name` 等其他参数之后。
- 增加参数重排回归测试，并保留账号前缀防误匹配覆盖。

## 根因与影响
原匹配器要求 `qq` 必须紧跟在 `CQ:at` 后。OneBot 发送参数顺序变化时，即使消息明确 @ 机器人，也会漏判并跳过自动回复。

## 验证
- `python3 -m pytest -q tests/test_napcat_delivery_semantics.py`
- 结果：6 passed
- `python3 -m pytest -q tests`
- 结果：458 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile onebot_message.py tests/test_napcat_delivery_semantics.py`
- `git diff --check`
