### PR TITLE
清理自定义模型名称控制字符

### DIFF
--- a/custom_model_import.py
+++ b/custom_model_import.py
@@ -43,6 +43,14 @@ class CustomModelImportError(Exception):
         self.params = params
 
 
+def _is_safe_folder_name_char(character: str) -> bool:
+    return (
+        character not in _INVALID_NAME_CHARS
+        and ord(character) >= 32
+        and ord(character) != 127
+    )
+
+
 def sanitize_character_name(name: str) -> str:
     """Turn a user-entered display name into a safe folder name.
 
@@ -50,7 +58,7 @@ def sanitize_character_name(name: str) -> str:
     work), so we only strip what the filesystem or the scanner can't handle.
     ModelManager skips entries starting with ``_``, so those are stripped too.
     """
-    cleaned = "".join(ch for ch in str(name or "") if ch not in _INVALID_NAME_CHARS)
+    cleaned = "".join(ch for ch in str(name or "") if _is_safe_folder_name_char(ch))
     cleaned = cleaned.strip().strip(".")
     while cleaned.startswith("_"):
         cleaned = cleaned[1:].lstrip()
@@ -59,7 +67,7 @@ def sanitize_character_name(name: str) -> str:
 
 
 def sanitize_costume_id(costume_id: str, fallback: str = "default") -> str:
-    cleaned = "".join(ch for ch in str(costume_id or "") if ch not in _INVALID_NAME_CHARS)
+    cleaned = "".join(ch for ch in str(costume_id or "") if _is_safe_folder_name_char(ch))
     cleaned = cleaned.strip().strip(".")
     while cleaned.startswith("_"):
         cleaned = cleaned[1:].lstrip()

--- a/tests/test_custom_model_import.py
+++ b/tests/test_custom_model_import.py
@@ -51,6 +51,39 @@ def _write_model3(root: Path) -> None:
 
 
 class CustomModelImportTest(unittest.TestCase):
+    def test_import_rejects_display_name_containing_only_control_characters(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            source.mkdir()
+            _write_model(source)
+
+            with (
+                patch.object(custom_model_import, "MODELS_DIR", root / "models"),
+                self.assertRaises(CustomModelImportError) as raised,
+            ):
+                import_from_folder(str(source), "\0\n\t", "default")
+
+            self.assertEqual("invalid_name", raised.exception.code)
+
+    def test_import_strips_control_characters_from_costume_id(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            models = root / "models"
+            source.mkdir()
+            _write_model(source)
+
+            with patch.object(custom_model_import, "MODELS_DIR", models):
+                _character, costumes = import_from_folder(
+                    str(source),
+                    "Test Character",
+                    "live\0_01",
+                )
+
+            self.assertEqual(["live_01"], costumes)
+            self.assertTrue((models / "Test Character" / "live_01" / "model.json").is_file())
+
     def test_delete_removes_marked_character_inside_models_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             models = Path(temp_dir) / "models"


### PR DESCRIPTION
## 修复内容
- 在自定义角色名和服装 ID 清理阶段移除 ASCII 控制字符。
- 全控制字符角色名统一返回既有 `invalid_name` 错误。
- 增加角色名及服装 ID 含 NUL 字符的回归测试。

## 根因与影响
名称清理此前只过滤路径保留字符，NUL 等控制字符会进入 `pathlib`/`shutil`。创建角色或服装目录时因此抛出未捕获的 `ValueError: embedded null character`，导入界面无法显示正常的业务错误。

## 验证
- `python3 -m pytest -q tests/test_custom_model_import.py`
- 结果：8 passed
- `python3 -m pytest -q tests`
- 结果：460 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile custom_model_import.py tests/test_custom_model_import.py`
- `git diff --check`
