### PR TITLE
限制 MCP 消息帧长度

### DIFF
--- a/mcp_base.py
+++ b/mcp_base.py
@@ -2,6 +2,8 @@ import json
 import sys
 from typing import Callable
 
+MAX_MCP_CONTENT_LENGTH = 64 * 1024 * 1024
+
 
 def iter_input_messages():
     stream = sys.stdin.buffer
@@ -39,6 +41,8 @@ def extract_message_from_buffer(buffer: bytes) -> tuple[str | None, bytes]:
                 break
         if content_length is None:
             raise ValueError("Missing Content-Length header")
+        if not 0 <= content_length <= MAX_MCP_CONTENT_LENGTH:
+            raise ValueError("Content-Length is outside the allowed range")
         body_start = header_end + 4
         body_end = body_start + content_length
         if len(buffer) < body_end:

--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -14,6 +14,7 @@ from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequ
 
 from i18n_manager import tr as _tr
 from app_info import APP_NAME
+from mcp_base import MAX_MCP_CONTENT_LENGTH
 from process_utils import app_base_dir, hidden_subprocess_kwargs, run_off_gui_thread
 from tool_arguments import parse_tool_arguments
 
@@ -811,6 +812,11 @@ def _extract_stdio_message(buffer: bytes) -> tuple[dict | None, bytes]:
                 break
         if content_length is None:
             raise RuntimeError(_tr("McpBridge.missing_content_length", default="MCP server response missing Content-Length"))
+        if not 0 <= content_length <= MAX_MCP_CONTENT_LENGTH:
+            raise RuntimeError(_tr(
+                "McpBridge.invalid_content_length",
+                default="MCP server response Content-Length is outside the allowed range",
+            ))
         body_start = header_end + 4
         body_end = body_start + content_length
         if len(buffer) < body_end:

--- a/tests/test_mcp_cancellation.py
+++ b/tests/test_mcp_cancellation.py
@@ -82,6 +82,22 @@ class McpCancellationTests(unittest.TestCase):
         self.assertEqual({"jsonrpc": "2.0", "id": 7, "result": {}}, client_message)
         self.assertEqual(b"", client_remaining)
 
+    def test_content_length_rejects_negative_size(self):
+        framed = b"Content-Length: -1\r\n\r\n{}"
+
+        with self.assertRaises(ValueError):
+            extract_message_from_buffer(framed)
+        with self.assertRaises(RuntimeError):
+            mcp_bridge._extract_stdio_message(framed)
+
+    def test_content_length_rejects_oversized_frame(self):
+        framed = b"Content-Length: 67108865\r\n\r\n{}"
+
+        with self.assertRaises(ValueError):
+            extract_message_from_buffer(framed)
+        with self.assertRaises(RuntimeError):
+            mcp_bridge._extract_stdio_message(framed)
+
     def test_stdio_close_terminates_process_before_closing_stdout(self):
         events = []
 


### PR DESCRIPTION
## 修复内容
- 为 MCP 服务端与客户端 stdio 帧解析共享 64 MiB 消息上限。
- 拒绝负数及超过上限的 `Content-Length`。
- 增加两类越界值在双向解析器中的回归测试。

## 根因与影响
负长度会造成反向切片及缓冲区错位，超大声明长度则会让读取线程持续积累数据等待一个不合理的帧，可能导致请求超时和内存无界增长。

## 验证
- `python3 -m pytest -q tests/test_mcp_cancellation.py`
- 结果：12 passed
- `python3 -m pytest -q tests`
- 结果：462 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile mcp_base.py mcp_bridge.py tests/test_mcp_cancellation.py`
- `git diff --check`
