### PR TITLE
限制流式工具调用索引

### DIFF
--- a/llm_manager.py
+++ b/llm_manager.py
@@ -55,6 +55,16 @@ _MOC3_ACTION_TAGS = (
 )
 
 _ACTION_INSTRUCTION_RE = re.compile(r"\n\n【重要指令】：必须在最后加动作标签：.*?(?=\n\n|$)", re.S)
+_MAX_STREAM_ITEM_INDEX = 1024
+
+
+def _coerce_stream_item_index(value) -> int | None:
+    try:
+        index = int(value)
+    except (TypeError, ValueError):
+        return None
+    return index if 0 <= index <= _MAX_STREAM_ITEM_INDEX else None
+
 
 def _make_prompt(intro: str, suffix: str) -> str:
     return f"{intro}\n\n【重要指令】：必须在最后加动作标签：{suffix}"
@@ -1091,22 +1101,26 @@ class LLMStreamWorker(_CancelableNetworkWorker):
         for call_delta in delta.get("tool_calls") or []:
             raw_index = call_delta.get("index")
             call_id = str(call_delta.get("id", "") or "")
-            if raw_index is None and call_id:
-                index = next(
-                    (
-                        item_index
-                        for item_index, item in enumerate(self._stream_tool_calls)
-                        if item.get("id") == call_id
-                    ),
-                    len(self._stream_tool_calls),
-                )
+            matching_index = next(
+                (
+                    item_index
+                    for item_index, item in enumerate(self._stream_tool_calls)
+                    if call_id and item.get("id") == call_id
+                ),
+                None,
+            )
+            if raw_index is None and matching_index is not None:
+                index = matching_index
             elif raw_index is None and len(self._stream_tool_calls) == 1:
                 index = 0
             else:
-                try:
-                    index = int(raw_index if raw_index is not None else len(self._stream_tool_calls))
-                except (TypeError, ValueError):
-                    index = len(self._stream_tool_calls)
+                index = _coerce_stream_item_index(raw_index)
+                if index is None:
+                    index = (
+                        matching_index
+                        if matching_index is not None
+                        else len(self._stream_tool_calls)
+                    )
             while len(self._stream_tool_calls) <= index:
                 self._stream_tool_calls.append({
                     "id": "",
@@ -1553,15 +1567,16 @@ class ResponsesStreamWorker(_CancelableNetworkWorker):
 
     def _function_call_target(self, item_id, output_index):
         item_id = str(item_id or "")
-        try:
-            index = int(output_index)
-        except (TypeError, ValueError):
-            index = len(self._stream_tool_calls)
         for target in self._stream_tool_calls:
             if item_id and target.get("_item_id") == item_id:
                 return target
-            if target.get("_output_index") == index:
-                return target
+        index = _coerce_stream_item_index(output_index)
+        if index is not None:
+            for target in self._stream_tool_calls:
+                if target.get("_output_index") == index:
+                    return target
+        else:
+            index = len(self._stream_tool_calls)
         target = {
             "id": "",
             "type": "function",

--- a/tests/test_responses_tool_runtime.py
+++ b/tests/test_responses_tool_runtime.py
@@ -15,6 +15,46 @@ from local_tools import responses_tools
 
 
 class ResponsesToolRuntimeTests(unittest.TestCase):
+    def test_chat_tool_call_negative_index_does_not_overwrite_previous_call(self):
+        worker = LLMStreamWorker("https://example.com/v1", "key", "model", [])
+        worker._collect_tool_call_delta({"tool_calls": [{
+            "index": 0,
+            "id": "call-first",
+            "function": {"name": "first", "arguments": "{}"},
+        }]})
+        worker._collect_tool_call_delta({"tool_calls": [{
+            "index": -1,
+            "id": "call-second",
+            "function": {"name": "second", "arguments": "{}"},
+        }]})
+
+        self.assertEqual(
+            ["first", "second"],
+            [call["function"]["name"] for call in worker._stream_tool_calls],
+        )
+
+    def test_chat_tool_call_oversized_index_does_not_allocate_sparse_entries(self):
+        worker = LLMStreamWorker("https://example.com/v1", "key", "model", [])
+        worker._collect_tool_call_delta({"tool_calls": [{
+            "index": 10000,
+            "id": "call-first",
+            "function": {"name": "first", "arguments": "{}"},
+        }]})
+
+        self.assertEqual(1, len(worker._stream_tool_calls))
+        self.assertEqual("call-first", worker._stream_tool_calls[0]["id"])
+
+    def test_responses_invalid_output_indexes_do_not_merge_distinct_calls(self):
+        worker = ResponsesStreamWorker(
+            "https://example.com/v1/responses", "key", "model", []
+        )
+
+        first = worker._function_call_target("fc-first", -1)
+        second = worker._function_call_target("fc-second", -1)
+
+        self.assertIsNot(first, second)
+        self.assertEqual(2, len(worker._stream_tool_calls))
+
     def test_missing_tool_call_ids_are_unique_across_calls_and_rounds(self):
         calls = [
             {"function": {"name": "first", "arguments": "{}"}},


### PR DESCRIPTION
## 修复内容
- 将 Chat Completions 与 Responses 流事件索引限制在合理范围内。
- 非法索引优先按调用 ID 关联，否则安全追加，避免覆盖现有调用。
- 增加负索引覆盖、超大稀疏分配及 Responses 错误合并的回归测试。

## 根因与影响
负 `index` 会通过 Python 负下标写入上一条工具调用，超大索引会补齐成千上万个空条目；Responses 的非法 `output_index` 则会把不同调用合并为同一条，导致工具名和参数错乱。

## 验证
- `python3 -m pytest -q tests/test_responses_tool_runtime.py`
- 结果：19 passed, 2 subtests passed
- `python3 -m pytest -q tests`
- 结果：465 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile llm_manager.py tests/test_responses_tool_runtime.py`
- `git diff --check`
