### PR TITLE
限制自定义模型 ZIP 解包资源

### DIFF
--- a/custom_model_import.py
+++ b/custom_model_import.py
@@ -27,6 +27,8 @@ MODEL_JSON_NAME = "model.json"
 MODEL3_JSON_SUFFIX = ".model3.json"
 _INVALID_NAME_CHARS = '<>:"/\\|?*'
 _MAX_NAME_LENGTH = 64
+_MAX_ZIP_MEMBERS = 10_000
+_MAX_ZIP_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
 
 
 class CustomModelImportError(Exception):
@@ -364,10 +366,20 @@ def import_from_zip(zip_path: str, display_name: str,
 
 
 def _safe_extract_zip(zf: zipfile.ZipFile, dest: Path) -> None:
-    """Extract a zip, rejecting path traversal (Zip Slip) entries."""
+    """Extract a zip, rejecting unsafe paths and resource usage."""
+    members = zf.infolist()
+    if len(members) > _MAX_ZIP_MEMBERS:
+        raise CustomModelImportError("bad_zip", detail="too many files in archive")
+    unpacked_size = sum(
+        max(0, int(member.file_size))
+        for member in members
+        if not member.is_dir()
+    )
+    if unpacked_size > _MAX_ZIP_UNCOMPRESSED_BYTES:
+        raise CustomModelImportError("bad_zip", detail="archive is too large when extracted")
     dest = dest.resolve()
-    for member in zf.namelist():
-        target = (dest / member).resolve()
+    for member in members:
+        target = (dest / member.filename).resolve()
         if dest != target and dest not in target.parents:
             raise CustomModelImportError("bad_zip", detail="unsafe path in archive")
     zf.extractall(dest)

--- a/tests/test_custom_model_import.py
+++ b/tests/test_custom_model_import.py
@@ -1,8 +1,10 @@
 import json
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import custom_model_import
 from custom_model_import import CustomModelImportError, import_from_folder
@@ -51,6 +53,68 @@ def _write_model3(root: Path) -> None:
 
 
 class CustomModelImportTest(unittest.TestCase):
+    def test_zip_import_accepts_model_within_resource_limits(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            models = root / "models"
+            archive_path = root / "model.zip"
+            source.mkdir()
+            _write_model(source)
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                for item in source.rglob("*"):
+                    if item.is_file():
+                        archive.write(item, item.relative_to(source))
+
+            with patch.object(custom_model_import, "MODELS_DIR", models):
+                character, costumes = custom_model_import.import_from_zip(
+                    str(archive_path),
+                    "Zip Character",
+                    "default",
+                )
+
+            self.assertEqual("Zip Character", character)
+            self.assertEqual(["default"], costumes)
+            self.assertTrue((models / character / "default" / "model.json").is_file())
+
+    def test_zip_extract_rejects_excessive_uncompressed_size(self):
+        archive = Mock()
+        archive.infolist.return_value = [SimpleNamespace(
+            filename="model.bin",
+            file_size=custom_model_import._MAX_ZIP_UNCOMPRESSED_BYTES + 1,
+            is_dir=lambda: False,
+        )]
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            self.assertRaises(CustomModelImportError) as raised,
+        ):
+            custom_model_import._safe_extract_zip(archive, Path(temp_dir))
+
+        self.assertEqual("bad_zip", raised.exception.code)
+        archive.extractall.assert_not_called()
+
+    def test_zip_extract_rejects_excessive_member_count(self):
+        members = [
+            SimpleNamespace(
+                filename=f"file-{index}.bin",
+                file_size=0,
+                is_dir=lambda: False,
+            )
+            for index in range(custom_model_import._MAX_ZIP_MEMBERS + 1)
+        ]
+        archive = Mock()
+        archive.infolist.return_value = members
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            self.assertRaises(CustomModelImportError) as raised,
+        ):
+            custom_model_import._safe_extract_zip(archive, Path(temp_dir))
+
+        self.assertEqual("bad_zip", raised.exception.code)
+        archive.extractall.assert_not_called()
+
     def test_import_rejects_display_name_containing_only_control_characters(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## 修复内容
- 自定义模型 ZIP 在解包前限制为最多 10,000 个成员、2 GiB 总展开体积。
- 保留既有 Zip Slip 路径校验，并复用同一份成员元数据。
- 增加正常 ZIP 导入、超大展开体积及超多成员回归测试。

## 根因与影响
原实现只验证成员路径，随后无上限调用 `extractall`。高压缩比或超多小文件归档可能占满临时磁盘、拖垮导入进程，且错误发生在大量数据已经写入之后。

## 验证
- `python3 -m pytest -q tests/test_custom_model_import.py`
- 结果：11 passed
- `python3 -m pytest -q tests`
- 结果：468 passed, 1 skipped, 72 subtests passed
- `python3 -m py_compile custom_model_import.py tests/test_custom_model_import.py`
- `git diff --check`
