### PR TITLE
统一处理 ZIP 解包异常

### DIFF
--- a/custom_model_import.py
+++ b/custom_model_import.py
@@ -360,7 +360,13 @@ def import_from_zip(zip_path: str, display_name: str,
         try:
             with zipfile.ZipFile(archive) as zf:
                 _safe_extract_zip(zf, tmp_root)
-        except (zipfile.BadZipFile, OSError) as exc:
+        except (
+            zipfile.BadZipFile,
+            zipfile.LargeZipFile,
+            OSError,
+            RuntimeError,
+            NotImplementedError,
+        ) as exc:
             raise CustomModelImportError("bad_zip", detail=str(exc)) from exc
         return _import_from_dir(tmp_root, display_name, costume_id, archive.name)
 

--- a/tests/test_custom_model_import.py
+++ b/tests/test_custom_model_import.py
@@ -53,6 +53,37 @@ def _write_model3(root: Path) -> None:
 
 
 class CustomModelImportTest(unittest.TestCase):
+    def test_zip_import_wraps_extraction_runtime_errors(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = Path(temp_dir) / "model.zip"
+            archive_path.write_bytes(b"zip")
+
+            for error in (
+                RuntimeError("Bad password for file"),
+                NotImplementedError("unsupported compression method"),
+            ):
+                with (
+                    self.subTest(error=type(error).__name__),
+                    patch.object(
+                        custom_model_import.zipfile,
+                        "is_zipfile",
+                        return_value=True,
+                    ),
+                    patch.object(custom_model_import.zipfile, "ZipFile"),
+                    patch.object(
+                        custom_model_import,
+                        "_safe_extract_zip",
+                        side_effect=error,
+                    ),
+                    self.assertRaises(CustomModelImportError) as raised,
+                ):
+                    custom_model_import.import_from_zip(
+                        str(archive_path),
+                        "Zip Character",
+                    )
+
+                self.assertEqual("bad_zip", raised.exception.code)
+
     def test_zip_import_accepts_model_within_resource_limits(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## 修复内容
- 将加密 ZIP、超大 ZIP 及不支持压缩算法的解包异常统一转换为 `CustomModelImportError("bad_zip")`。
- 保留具体异常文本供现有错误提示展示。
- 增加密码错误与不支持压缩算法的回归子测试。

## 根因与影响
ZIP 打开/解包阶段此前只捕获 `BadZipFile` 和 `OSError`。密码保护归档会抛出 `RuntimeError`，不支持的压缩算法会抛出 `NotImplementedError`，二者会逃出导入界面的业务错误处理。

## 验证
- `python3 -m pytest -q tests/test_custom_model_import.py`
- 结果：12 passed, 2 subtests passed
- `python3 -m pytest -q tests`
- 结果：469 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile custom_model_import.py tests/test_custom_model_import.py`
- `git diff --check`
