### PR TITLE
处理 ZIP 格式探测读取错误

### DIFF
--- a/custom_model_import.py
+++ b/custom_model_import.py
@@ -352,7 +352,11 @@ def import_from_zip(zip_path: str, display_name: str,
     archive = Path(zip_path)
     if not archive.is_file():
         raise CustomModelImportError("source_missing")
-    if not zipfile.is_zipfile(archive):
+    try:
+        is_zip = zipfile.is_zipfile(archive)
+    except OSError as exc:
+        raise CustomModelImportError("bad_zip", detail=str(exc)) from exc
+    if not is_zip:
         raise CustomModelImportError("bad_zip")
 
     with tempfile.TemporaryDirectory(prefix="bandori_custom_model_") as tmp:

--- a/tests/test_custom_model_import.py
+++ b/tests/test_custom_model_import.py
@@ -53,6 +53,26 @@ def _write_model3(root: Path) -> None:
 
 
 class CustomModelImportTest(unittest.TestCase):
+    def test_zip_import_wraps_format_probe_io_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = Path(temp_dir) / "model.zip"
+            archive_path.write_bytes(b"zip")
+
+            with (
+                patch.object(
+                    custom_model_import.zipfile,
+                    "is_zipfile",
+                    side_effect=PermissionError("archive is not readable"),
+                ),
+                self.assertRaises(CustomModelImportError) as raised,
+            ):
+                custom_model_import.import_from_zip(
+                    str(archive_path),
+                    "Zip Character",
+                )
+
+            self.assertEqual("bad_zip", raised.exception.code)
+
     def test_zip_import_wraps_extraction_runtime_errors(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             archive_path = Path(temp_dir) / "model.zip"


### PR DESCRIPTION
## 修复内容
- 捕获 ZIP 格式探测阶段的文件读取错误并转换为 `CustomModelImportError("bad_zip")`。
- 保留底层错误详情供现有界面提示使用。
- 增加不可读取归档的回归测试。

## 根因与影响
`zipfile.is_zipfile()` 位于既有异常转换之外。权限错误或底层读取失败会以裸 `OSError` 逃出，导致导入界面无法按损坏 ZIP 统一处理。

## 验证
- `python3 -m pytest -q tests/test_custom_model_import.py`
- 结果：13 passed, 2 subtests passed
- `python3 -m pytest -q tests`
- 结果：470 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile custom_model_import.py tests/test_custom_model_import.py`
- `git diff --check`
