### PR TITLE
修复 Token 命令损坏统计崩溃

### DIFF
--- a/chat_commands.py
+++ b/chat_commands.py
@@ -327,6 +327,15 @@ def _resolve_name(character: str, name_resolver) -> str:
     return character or _tr("ChatCommand.default_character", default="桌宠")
 
 
+def _safe_stat_int(value, default=0):
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
 def _handle_token_usage(token_usage_resolver) -> dict:
     if not callable(token_usage_resolver):
         return {
@@ -340,13 +349,15 @@ def _handle_token_usage(token_usage_resolver) -> dict:
     except Exception as exc:
         log_swallowed("chat_commands._handle_token_usage", exc)
         stats = {}
+    if not isinstance(stats, dict):
+        stats = {}
     estimated_note = (
         _tr("ChatCommand.tokens_contains_estimate", default="（包含估算值）")
         if stats.get("estimated")
         else ""
     )
-    untracked_count = int(stats.get("untracked_count", 0) or 0)
-    estimated_request_count = int(stats.get("estimated_request_count", 0) or 0)
+    untracked_count = _safe_stat_int(stats.get("untracked_count"))
+    estimated_request_count = _safe_stat_int(stats.get("estimated_request_count"))
     untracked_note = ""
     if estimated_request_count:
         untracked_note += "\n" + _tr(
@@ -360,11 +371,7 @@ def _handle_token_usage(token_usage_resolver) -> dict:
             default="未统计历史回复：{count}",
             count=f"{untracked_count:,}",
         )
-    history_message_limit = stats.get("history_message_limit")
-    try:
-        history_message_limit = int(history_message_limit)
-    except (TypeError, ValueError):
-        history_message_limit = None
+    history_message_limit = _safe_stat_int(stats.get("history_message_limit"), None)
     if history_message_limit == 0:
         history_message_limit_text = _tr(
             "SettingsWindow.llm_history_message_limit_unlimited",
@@ -391,22 +398,22 @@ def _handle_token_usage(token_usage_resolver) -> dict:
                 "请求数：{requests}{untracked_note}"
             ),
             estimated_note=estimated_note,
-            total=f"{int(stats.get('total_tokens', 0) or 0):,}",
-            input=f"{int(stats.get('input_tokens', 0) or 0):,}",
-            output=f"{int(stats.get('output_tokens', 0) or 0):,}",
-            message_count=f"{int(stats.get('message_count', 0) or 0):,}",
+            total=f"{_safe_stat_int(stats.get('total_tokens')):,}",
+            input=f"{_safe_stat_int(stats.get('input_tokens')):,}",
+            output=f"{_safe_stat_int(stats.get('output_tokens')):,}",
+            message_count=f"{_safe_stat_int(stats.get('message_count')):,}",
             next_history_message_count=(
-                f"{int(stats.get('next_history_message_count', 0) or 0):,}"
+                f"{_safe_stat_int(stats.get('next_history_message_count')):,}"
             ),
             history_message_limit=history_message_limit_text,
-            next_input=f"{int(stats.get('next_input_tokens', 0) or 0):,}",
+            next_input=f"{_safe_stat_int(stats.get('next_input_tokens')):,}",
             next_history_tokens=(
-                f"{int(stats.get('next_history_tokens', 0) or 0):,}"
+                f"{_safe_stat_int(stats.get('next_history_tokens')):,}"
             ),
             next_context_tokens=(
-                f"{int(stats.get('next_context_tokens', 0) or 0):,}"
+                f"{_safe_stat_int(stats.get('next_context_tokens')):,}"
             ),
-            requests=f"{int(stats.get('request_count', 0) or 0):,}",
+            requests=f"{_safe_stat_int(stats.get('request_count')):,}",
             untracked_note=untracked_note,
         )
     }

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -167,6 +167,41 @@ class TokenUsageTests(unittest.TestCase):
             )
         )
 
+    def test_tokens_command_tolerates_malformed_stat_fields(self):
+        result = handle_command(
+            object(),
+            "@tokens",
+            token_usage_resolver=lambda: {
+                "input_tokens": "unknown",
+                "output_tokens": float("inf"),
+                "total_tokens": {},
+                "request_count": [],
+                "untracked_count": {"broken": True},
+                "estimated_request_count": object(),
+                "message_count": None,
+                "next_history_message_count": "bad",
+                "history_message_limit": "bad",
+                "next_input_tokens": "bad",
+                "next_history_tokens": "bad",
+                "next_context_tokens": "bad",
+            },
+            publish=False,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertIn("0", result["message"])
+
+    def test_tokens_command_tolerates_non_mapping_stats(self):
+        result = handle_command(
+            object(),
+            "@tokens",
+            token_usage_resolver=lambda: ["invalid"],
+            publish=False,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertIn("0", result["message"])
+
     def test_chat_stream_worker_reads_usage_chunk(self):
         worker = LLMStreamWorker("https://example.com/v1", "key", "model", [])
         worker._process_line(


### PR DESCRIPTION
## 修复内容
- `@tokens` 对每个统计字段执行容错整数转换。
- 损坏、无穷或非映射统计安全降级，同时保留缺失历史上限的原有显示语义。
- 增加损坏字段与非字典解析结果回归测试。

## 根因与影响
统计解析器调用本身有异常保护，但返回数据随后被多次直接传给 `int()`。数据库或兼容统计源提供损坏字段时，`@tokens` 会抛出 `TypeError`、`ValueError` 或 `OverflowError`，中断聊天命令处理。

## 验证
- `python3 -m pytest -q tests/test_token_usage.py`
- 结果：12 passed
- `python3 -m pytest -q tests`
- 结果：472 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile chat_commands.py tests/test_token_usage.py`
- `git diff --check`
