### PR TITLE
修复 Token 用量无穷值溢出

### DIFF
--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -44,6 +44,17 @@ class TokenUsageTests(unittest.TestCase):
         self.assertEqual(responses["input_tokens"], 80)
         self.assertEqual(responses["output_tokens"], 20)
 
+    def test_normalize_usage_tolerates_infinite_provider_counts(self):
+        usage = normalize_token_usage({
+            "input_tokens": float("inf"),
+            "output_tokens": float("-inf"),
+            "total_tokens": float("inf"),
+        })
+
+        self.assertEqual(0, usage["input_tokens"])
+        self.assertEqual(0, usage["output_tokens"])
+        self.assertEqual(0, usage["total_tokens"])
+
     def test_merges_exact_and_estimated_usage(self):
         merged = merge_token_usage(
             {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},

--- a/token_usage.py
+++ b/token_usage.py
@@ -52,7 +52,7 @@ def history_message_query_limit(value, default: int) -> int | None:
 def _non_negative_int(value) -> int:
     try:
         return max(0, int(value or 0))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
 
 


### PR DESCRIPTION
## 修复内容
- Token 用量归一化将整数转换溢出与其他损坏数值一致降级为 0。
- 增加输入、输出及总计为正负无穷时的回归测试。

## 根因与影响
兼容 API 返回的 usage 字段会转换为非负整数。现有逻辑捕获了类型和格式错误，却遗漏 `int(float("inf"))` 产生的 `OverflowError`，导致 Chat Completions 或 Responses 流在处理 usage 块时中断。

## 验证
- `python3 -m pytest -q tests/test_token_usage.py`
- 结果：13 passed
- `python3 -m pytest -q tests`
- 结果：473 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile token_usage.py tests/test_token_usage.py`
- `git diff --check`
