### PR TITLE
修复历史消息上限溢出

### DIFF
--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -27,6 +27,11 @@ class TokenUsageTests(unittest.TestCase):
         self.assertEqual(history_message_limit_from_slider(101), 0)
         self.assertIsNone(history_message_query_limit(0, 40))
 
+    def test_history_message_limit_tolerates_infinite_values(self):
+        self.assertEqual(normalize_history_message_limit(float("inf"), 40), 40)
+        self.assertEqual(normalize_history_message_limit(None, float("inf")), 2)
+        self.assertEqual(history_message_limit_from_slider(float("inf")), 2)
+
     def test_normalizes_both_api_usage_shapes(self):
         chat = normalize_token_usage({
             "prompt_tokens": 120,

--- a/token_usage.py
+++ b/token_usage.py
@@ -18,8 +18,11 @@ HISTORY_MESSAGE_LIMIT_SLIDER_MAX = 101
 def normalize_history_message_limit(value, default: int) -> int:
     try:
         parsed = int(value)
-    except (TypeError, ValueError):
-        parsed = int(default)
+    except (TypeError, ValueError, OverflowError):
+        try:
+            parsed = int(default)
+        except (TypeError, ValueError, OverflowError):
+            parsed = 2
     if parsed == HISTORY_MESSAGE_LIMIT_UNLIMITED:
         return HISTORY_MESSAGE_LIMIT_UNLIMITED
     return max(2, min(100, parsed))
@@ -37,7 +40,7 @@ def history_message_limit_to_slider(value, default: int) -> int:
 def history_message_limit_from_slider(value) -> int:
     try:
         parsed = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         parsed = 2
     if parsed >= HISTORY_MESSAGE_LIMIT_SLIDER_MAX:
         return HISTORY_MESSAGE_LIMIT_UNLIMITED


### PR DESCRIPTION
## 修复内容
- 历史消息上限归一化捕获整数转换溢出。
- 损坏的默认值安全回退至最小合法上限。
- 滑块同步同样处理无穷值。
- 增加主值、默认值与滑块值为 Infinity 的回归测试。

## 根因与影响
配置归一化仅捕获类型和格式错误，`int(Infinity)` 会抛出 `OverflowError`。损坏或外部编辑过的配置可能在聊天设置加载、历史查询限制计算或滑块同步时导致界面异常。

## 验证
- `python3 -m pytest -q tests/test_token_usage.py`
- 结果：14 passed
- `python3 -m pytest -q tests`
- 结果：474 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile token_usage.py tests/test_token_usage.py`
- `git diff --check`
