### PR TITLE
规范 MCP 服务超时配置

### DIFF
--- a/mcp_bridge.py
+++ b/mcp_bridge.py
@@ -30,6 +30,14 @@ _thread_local = threading.local()
 _APP_DIR = Path(app_base_dir()).resolve()
 
 
+def _server_timeout_seconds(server: dict) -> int:
+    try:
+        timeout = int(server.get("timeout_seconds", 30) or 30)
+    except (TypeError, ValueError, OverflowError):
+        timeout = 30
+    return max(1, min(3600, timeout))
+
+
 def mcp_proxy_tools(config: dict, exclude_native: bool = False) -> list[dict]:
     if not _mcp_enabled(config):
         return []
@@ -411,7 +419,7 @@ def _request_http_json_direct(server: dict, payload: dict, cancel_event=None) ->
     url = str(server.get("url", "") or "").strip()
     if not url:
         raise ValueError(_tr("McpBridge.http_url_empty", default="HTTP MCP server url is empty"))
-    timeout = int(server.get("timeout_seconds", 30) or 30)
+    timeout = _server_timeout_seconds(server)
     auth = str(server.get("authorization", "") or "").strip()
     body = json.dumps(payload).encode("utf-8")
 
@@ -497,7 +505,7 @@ def _send_http_cancel_notification(server: dict, request_id):
         },
     }
     retry_server = dict(server)
-    retry_server["timeout_seconds"] = min(2, int(server.get("timeout_seconds", 30) or 30))
+    retry_server["timeout_seconds"] = min(2, _server_timeout_seconds(server))
     try:
         _request_http_json_direct(retry_server, cancellation, None)
     except Exception:
@@ -732,7 +740,7 @@ class StdioMcpClient:
             if params is not None:
                 message["params"] = params
             self._write(message)
-            deadline = time.monotonic() + int(self._server.get("timeout_seconds", 30) or 30)
+            deadline = time.monotonic() + _server_timeout_seconds(self._server)
             while time.monotonic() < deadline:
                 if self._reader_error is not None:
                     raise RuntimeError(str(self._reader_error))

--- a/tests/test_mcp_cancellation.py
+++ b/tests/test_mcp_cancellation.py
@@ -14,6 +14,15 @@ class McpCancellationTests(unittest.TestCase):
     def tearDown(self):
         mcp_bridge.close_mcp_clients()
 
+    def test_server_timeout_is_normalized_for_malformed_and_extreme_values(self):
+        self.assertEqual(
+            30,
+            mcp_bridge._server_timeout_seconds({"timeout_seconds": float("inf")}),
+        )
+        self.assertEqual(1, mcp_bridge._server_timeout_seconds({"timeout_seconds": -5}))
+        self.assertEqual(3600, mcp_bridge._server_timeout_seconds({"timeout_seconds": 9999}))
+        self.assertEqual(45, mcp_bridge._server_timeout_seconds({"timeout_seconds": "45"}))
+
     def test_stdio_request_stops_when_cancelled(self):
         client = object.__new__(mcp_bridge.StdioMcpClient)
         client._server = {"timeout_seconds": 30}


### PR DESCRIPTION
## 修复内容
- 集中解析 MCP `timeout_seconds`，损坏值回退为 30 秒。
- 将有效超时限制在 1–3600 秒。
- HTTP 请求、取消重试和 stdio 请求统一复用安全值。
- 增加无穷、负数、超大值及数字字符串回归测试。

## 根因与影响
三条 MCP 请求路径分别直接调用 `int(timeout_seconds)`。损坏配置中的 Infinity 会在请求前抛 `OverflowError`，负数或超大值则产生无效或不合理的网络截止时间。

## 验证
- `python3 -m pytest -q tests/test_mcp_cancellation.py`
- 结果：13 passed
- `python3 -m pytest -q tests`
- 结果：475 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile mcp_bridge.py tests/test_mcp_cancellation.py`
- `git diff --check`
