### PR TITLE
修复自动续写配置溢出

### DIFF
--- a/llm_manager.py
+++ b/llm_manager.py
@@ -733,7 +733,7 @@ def _auto_continue_limit(tool_config: dict) -> int:
         return 0
     try:
         return max(1, min(20, int(tool_config.get("llm_auto_continue_max_turns", 5))))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 5
 
 

--- a/local_tools.py
+++ b/local_tools.py
@@ -525,7 +525,7 @@ def _run_poke_user_tool_call(arguments, tool_config: dict | None = None) -> dict
 def _normalize_auto_continue_max_turns(value) -> int:
     try:
         return max(1, min(20, int(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 5
 
 
@@ -534,7 +534,7 @@ def _run_auto_continue_tool_call(arguments, tool_config: dict) -> dict:
     max_turns = _normalize_auto_continue_max_turns(tool_config.get("llm_auto_continue_max_turns", 5))
     try:
         current = max(0, int(tool_config.get("_auto_continue_count", 0) or 0))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         current = 0
     remaining = max(0, max_turns - current - 1)
     return {

--- a/tests/test_local_tool_safety.py
+++ b/tests/test_local_tool_safety.py
@@ -32,6 +32,16 @@ class LocalToolSafetyTests(unittest.TestCase):
         self.assertFalse(local_tools.should_prefetch_web_search("search latest news"))
         self.assertFalse(local_tools.should_prefetch_web_search("今天天气"))
 
+    def test_auto_continue_tolerates_infinite_limit_and_runtime_count(self):
+        self.assertEqual(5, local_tools._normalize_auto_continue_max_turns(float("inf")))
+
+        result = local_tools._run_auto_continue_tool_call({}, {
+            "llm_auto_continue_max_turns": 5,
+            "_auto_continue_count": float("inf"),
+        })
+
+        self.assertIn("剩余", result["content"])
+
     def test_invalid_json_never_reaches_side_effecting_tool_handlers(self):
         invalid = '{"value":'
         with (

--- a/tests/test_worker_helper_deduplication.py
+++ b/tests/test_worker_helper_deduplication.py
@@ -8,6 +8,7 @@ def test_stream_workers_share_auto_continue_and_prefetch_helpers():
     assert _auto_continue_limit({}) == 0
     assert _auto_continue_limit({"llm_auto_continue_enabled": True, "llm_auto_continue_max_turns": 99}) == 20
     assert _auto_continue_limit({"llm_auto_continue_enabled": True, "llm_auto_continue_max_turns": "bad"}) == 5
+    assert _auto_continue_limit({"llm_auto_continue_enabled": True, "llm_auto_continue_max_turns": float("inf")}) == 5
     assert _prefetch_web_search_context({"_latest_user_text": "latest news"}) == ""
 
 


### PR DESCRIPTION
## 修复内容
- 自动续写流管理器安全处理无穷上限配置。
- 本地自动续写工具同步处理上限和运行计数溢出。
- 增加初始化与工具执行两条路径的回归测试。

## 根因与影响
自动续写的三次数值转换只捕获类型和格式错误。配置或运行快照包含 Infinity 时会抛出 `OverflowError`，可能在请求开始前中止回复，或使自动续写工具调用失败。

## 验证
- `python3 -m pytest -q tests/test_worker_helper_deduplication.py tests/test_local_tool_safety.py`
- 结果：17 passed, 4 subtests passed
- `python3 -m pytest -q tests`
- 结果：476 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile llm_manager.py local_tools.py tests/test_worker_helper_deduplication.py tests/test_local_tool_safety.py`
- `git diff --check`
