### PR TITLE
修复网页工具限制参数溢出

### DIFF
--- a/local_tools.py
+++ b/local_tools.py
@@ -414,7 +414,7 @@ def run_local_tool_call(name: str, arguments, tool_config: dict | None = None) -
     )
     try:
         max_results = int(arguments.get("max_results", 5) or 5)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         max_results = 5
     max_results = max(1, min(8, max_results))
     engine = _normalize_search_engine((tool_config or {}).get("llm_web_search_engine", "bing_cn"))
@@ -426,7 +426,7 @@ def _run_web_fetch_tool_call(arguments, tool_config: dict | None = None) -> dict
     url = str(arguments.get("url", "") or "").strip()
     try:
         max_chars = int(arguments.get("max_chars", 6000) or 6000)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         max_chars = 6000
     max_chars = max(500, min(12000, max_chars))
     return {"content": web_fetch(url, max_chars=max_chars), "extra_messages": []}

--- a/tests/test_local_tool_safety.py
+++ b/tests/test_local_tool_safety.py
@@ -84,6 +84,25 @@ class LocalToolSafetyTests(unittest.TestCase):
         web_search.assert_called_once_with("Bandori", max_results=2, engine="bing_cn")
         self.assertEqual("result", result["content"])
 
+    def test_web_tools_tolerate_infinite_result_limits(self):
+        with (
+            patch("local_tools.web_search", return_value="search") as web_search,
+            patch("local_tools.web_fetch", return_value="fetch") as web_fetch,
+        ):
+            search_result = local_tools.run_local_tool_call(
+                local_tools.WEB_SEARCH_TOOL_NAME,
+                {"query": "Bandori", "max_results": float("inf")},
+            )
+            fetch_result = local_tools.run_local_tool_call(
+                local_tools.WEB_FETCH_TOOL_NAME,
+                {"url": "https://example.com", "max_chars": float("inf")},
+            )
+
+        web_search.assert_called_once_with("Bandori", max_results=5, engine="bing_cn")
+        web_fetch.assert_called_once_with("https://example.com", max_chars=6000)
+        self.assertEqual("search", search_result["content"])
+        self.assertEqual("fetch", fetch_result["content"])
+
     def test_tool_argument_normalizer_is_shared_and_preserves_fallbacks(self):
         self.assertEqual({"value": 1}, parse_tool_arguments('{"value":1}'))
         self.assertEqual({}, parse_tool_arguments("{broken"))


### PR DESCRIPTION
## 修复内容
- 网页搜索 `max_results` 对整数溢出回退为 5。
- 网页抓取 `max_chars` 对整数溢出回退为 6000。
- 增加两种工具接收 Infinity 参数时仍正常执行的回归测试。

## 根因与影响
模型生成的 JSON 数值 `1e309` 会被解析为 Infinity。两个网页工具只捕获类型和格式错误，随后 `int(Infinity)` 抛出 `OverflowError`，导致本轮工具调用中断而不是使用默认限制。

## 验证
- `python3 -m pytest -q tests/test_local_tool_safety.py`
- 结果：16 passed, 4 subtests passed
- `python3 -m pytest -q tests`
- 结果：477 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile local_tools.py tests/test_local_tool_safety.py`
- `git diff --check`
