### PR TITLE
修复屏幕感知数值溢出

### DIFF
--- a/screen_awareness.py
+++ b/screen_awareness.py
@@ -16,7 +16,7 @@ SCREEN_AWARENESS_MODEL_MODE_AUX = "aux"
 def clamp_screen_awareness_interval(value) -> int:
     try:
         minutes = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         minutes = 30
     return max(SCREEN_AWARENESS_MIN_INTERVAL_MINUTES, min(SCREEN_AWARENESS_MAX_INTERVAL_MINUTES, minutes))
 
@@ -24,7 +24,7 @@ def clamp_screen_awareness_interval(value) -> int:
 def clamp_screen_awareness_screenshot_width(value) -> int:
     try:
         width = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         width = 1920
     return max(640, min(1920, width))
 

--- a/tests/test_screen_awareness.py
+++ b/tests/test_screen_awareness.py
@@ -10,6 +10,8 @@ from screen_awareness import (
     SCREEN_AWARENESS_MODEL_MODE_AUX,
     SCREEN_AWARENESS_MODEL_MODE_MAIN,
     ScreenAwarenessVisionWorker,
+    clamp_screen_awareness_interval,
+    clamp_screen_awareness_screenshot_width,
     normalize_screen_awareness_model_mode,
     screen_awareness_aux_config,
     screen_awareness_desktop_state,
@@ -17,6 +19,10 @@ from screen_awareness import (
 
 
 class ScreenAwarenessTest(unittest.TestCase):
+    def test_numeric_settings_tolerate_infinite_values(self):
+        self.assertEqual(30, clamp_screen_awareness_interval(float("inf")))
+        self.assertEqual(1920, clamp_screen_awareness_screenshot_width(float("inf")))
+
     def test_model_mode_normalization_defaults_to_main(self):
         self.assertEqual(SCREEN_AWARENESS_MODEL_MODE_MAIN, normalize_screen_awareness_model_mode(None))
         self.assertEqual(SCREEN_AWARENESS_MODEL_MODE_MAIN, normalize_screen_awareness_model_mode("unknown"))


### PR DESCRIPTION
## 修复内容
- 屏幕感知间隔在整数溢出时回退为 30 分钟。
- 截图最大宽度在整数溢出时回退为 1920 像素。
- 增加两项配置为 Infinity 的回归测试。

## 根因与影响
两项屏幕感知配置仅捕获类型和格式错误。损坏配置中的 Infinity 会在定时策略或视觉 worker 截图前抛出 `OverflowError`，中止屏幕感知功能。

## 验证
- `python3 -m pytest -q tests/test_screen_awareness.py`
- 结果：16 passed
- `python3 -m pytest -q tests`
- 结果：478 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile screen_awareness.py tests/test_screen_awareness.py`
- `git diff --check`
