### PR TITLE
修复 Live2D 缩放配置溢出

### DIFF
--- a/live2d_quality.py
+++ b/live2d_quality.py
@@ -27,7 +27,7 @@ def normalize_live2d_quality(profile: str) -> str:
 def clamp_live2d_scale(value: Any, default: int = 100, use_device_pixel_ratio_default: bool = False) -> int:
     try:
         pct = int(round(float(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         pct = 0 if use_device_pixel_ratio_default else default
     if pct <= 0:
         if use_device_pixel_ratio_default:

--- a/tests/test_live2d_quality.py
+++ b/tests/test_live2d_quality.py
@@ -1,0 +1,17 @@
+import unittest
+
+from live2d_quality import clamp_live2d_scale
+
+
+class Live2DQualityTest(unittest.TestCase):
+    def test_scale_clamps_normal_values(self):
+        self.assertEqual(25, clamp_live2d_scale(1))
+        self.assertEqual(250, clamp_live2d_scale(250))
+        self.assertEqual(500, clamp_live2d_scale(999))
+
+    def test_scale_tolerates_infinite_config_value(self):
+        self.assertEqual(100, clamp_live2d_scale(float("inf")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容
- Live2D 缩放配置在浮点溢出时回退到既有默认缩放。
- 新增普通缩放裁剪与 Infinity 配置回归测试。

## 根因与影响
缩放值会依次经过 `float`、`round`、`int`。损坏配置中的 Infinity 在整数转换时抛出 `OverflowError`，可能阻止桌宠窗口或模型设置页面初始化。

## 验证
- `python3 -m pytest -q tests/test_live2d_quality.py`
- 结果：2 passed
- `python3 -m pytest -q tests`
- 结果：480 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile live2d_quality.py tests/test_live2d_quality.py`
- `git diff --check`
