### PR TITLE
修复主动关怀冷却配置溢出

### DIFF
--- a/proactive_care_policy.py
+++ b/proactive_care_policy.py
@@ -113,7 +113,7 @@ def _bool_value(value, default: bool = False) -> bool:
 def _int_value(value, default: int, minimum: int, maximum: int) -> int:
     try:
         number = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         number = default
     return max(minimum, min(maximum, number))
 

--- a/tests/test_proactive_care_policy.py
+++ b/tests/test_proactive_care_policy.py
@@ -10,6 +10,13 @@ from proactive_care_policy import (
 
 
 class ProactiveCarePolicyTest(unittest.TestCase):
+    def test_global_cooldown_tolerates_infinite_config_value(self):
+        policy = normalize_proactive_care_policy({
+            "global_cooldown_minutes": float("inf"),
+        })
+
+        self.assertEqual(30, policy["global_cooldown_minutes"])
+
     def test_default_policy_has_all_state_rules(self):
         policy = normalize_proactive_care_policy({})
 


### PR DESCRIPTION
## 修复内容
- 主动关怀全局冷却配置在整数溢出时回退到 30 分钟默认值。
- 增加 Infinity 配置的策略归一化回归测试。

## 根因与影响
主动关怀策略的整数规范化只捕获类型和格式错误。损坏配置中的 Infinity 会在策略评估前抛出 `OverflowError`，中止屏幕感知及生活提醒决策。

## 验证
- `python3 -m pytest -q tests/test_proactive_care_policy.py`
- 结果：7 passed, 3 subtests passed
- `python3 -m pytest -q tests`
- 结果：481 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile proactive_care_policy.py tests/test_proactive_care_policy.py`
- `git diff --check`
