### PR TITLE
修复截图数值转换溢出

### DIFF
--- a/screen_capture.py
+++ b/screen_capture.py
@@ -49,5 +49,5 @@ def desktop_bounds(fallback_width: int, fallback_height: int) -> tuple[int, int,
 def _int(value, default: int = 0) -> int:
     try:
         return int(round(float(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default

--- a/tests/test_screen_capture.py
+++ b/tests/test_screen_capture.py
@@ -1,0 +1,15 @@
+import unittest
+
+from screen_capture import _int
+
+
+class ScreenCaptureTest(unittest.TestCase):
+    def test_integer_conversion_rounds_normal_values(self):
+        self.assertEqual(13, _int(12.6, 100))
+
+    def test_integer_conversion_tolerates_infinite_value(self):
+        self.assertEqual(1280, _int(float("inf"), 1280))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容
- 共享截图整数转换在浮点溢出时使用调用方默认值。
- 新增正常舍入与 Infinity 回退测试。

## 根因与影响
底层截图入口会把最大宽度转换为整数，电脑工具和屏幕感知均可调用。Infinity 在 `round/ int` 阶段抛出 `OverflowError`，导致截图已经获取后仍中止处理。

## 验证
- `python3 -m pytest -q tests/test_screen_capture.py`
- 结果：2 passed
- `python3 -m pytest -q tests`
- 结果：483 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile screen_capture.py tests/test_screen_capture.py`
- `git diff --check`
