### PR TITLE
修复紧凑窗口配置溢出

### DIFF
--- a/compact_ai_window.py
+++ b/compact_ai_window.py
@@ -92,7 +92,7 @@ def _contrast_text(color: QColor) -> str:
 def _opacity_alpha(value) -> int:
     try:
         pct = int(round(float(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         pct = 44
     return max(15, min(100, pct)) * 255 // 100
 
@@ -100,7 +100,7 @@ def _opacity_alpha(value) -> int:
 def _font_size_from_config(value) -> int:
     try:
         size = int(round(float(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         size = 12
     return max(9, min(22, size))
 

--- a/tests/test_compact_ai_config.py
+++ b/tests/test_compact_ai_config.py
@@ -1,0 +1,17 @@
+import unittest
+
+from compact_ai_window import _font_size_from_config, _opacity_alpha
+
+
+class CompactAiConfigTest(unittest.TestCase):
+    def test_numeric_config_clamps_normal_values(self):
+        self.assertEqual(38, _opacity_alpha(15))
+        self.assertEqual(22, _font_size_from_config(30))
+
+    def test_numeric_config_tolerates_infinite_values(self):
+        self.assertEqual(112, _opacity_alpha(float("inf")))
+        self.assertEqual(12, _font_size_from_config(float("inf")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容
- 紧凑聊天窗口透明度配置溢出时回退为 44%。
- 字体大小配置溢出时回退为 12px。
- 新增正常裁剪与 Infinity 回退测试。

## 根因与影响
紧凑窗口恢复配置时会把透明度和字体值从浮点转换为整数。Infinity 会抛出 `OverflowError`，阻止窗口初始化或样式刷新。

## 验证
- `python3 -m pytest -q tests/test_compact_ai_config.py`
- 结果：2 passed
- `python3 -m pytest -q tests`
- 结果：485 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile compact_ai_window.py tests/test_compact_ai_config.py`
- `git diff --check`
