### PR TITLE
修复通用整数裁剪溢出

### DIFF
--- a/process_utils.py
+++ b/process_utils.py
@@ -448,7 +448,7 @@ def clamp_int(value: object, minimum: int, maximum: int, default: int | None = N
         default = minimum
     try:
         number = int(round(float(value)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         number = default
     return max(minimum, min(maximum, number))
 

--- a/tests/test_process_utils_clamp.py
+++ b/tests/test_process_utils_clamp.py
@@ -1,0 +1,16 @@
+import unittest
+
+from process_utils import clamp_int
+
+
+class ProcessUtilsClampTest(unittest.TestCase):
+    def test_integer_clamp_rounds_and_limits_normal_values(self):
+        self.assertEqual(13, clamp_int(12.6, 1, 100, 20))
+        self.assertEqual(100, clamp_int(500, 1, 100, 20))
+
+    def test_integer_clamp_tolerates_infinite_value(self):
+        self.assertEqual(38472, clamp_int(float("inf"), 1024, 65535, 38472))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容
- 通用 `clamp_int` 在浮点转整数溢出时使用调用方默认值。
- 新增正常舍入、边界裁剪和 Infinity 回退测试。

## 根因与影响
`clamp_int` 被 AI 状态端口、聊天集成端口等启动配置复用。Infinity 在 `round/ int` 阶段抛出 `OverflowError`，可能阻止主程序或设置页面加载。

## 验证
- `python3 -m pytest -q tests/test_process_utils_clamp.py`
- 结果：2 passed
- `python3 -m pytest -q tests`
- 结果：487 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile process_utils.py tests/test_process_utils_clamp.py`
- `git diff --check`
