### PR TITLE
修复提醒数值规范化溢出

### DIFF
--- a/reminder_core.py
+++ b/reminder_core.py
@@ -213,7 +213,7 @@ def compute_next_alarm_at(time_text: str, repeat_days=None, after: datetime | No
 def _clamp_minutes(value, default: int, minimum: int, maximum: int) -> int:
     try:
         minutes = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         minutes = default
     return max(minimum, min(maximum, minutes))
 
@@ -238,7 +238,7 @@ def _coerce_bool(value, default: bool = False) -> bool:
 def _coerce_int(value, default: int = 0) -> int:
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
 
 
@@ -436,7 +436,7 @@ def normalize_proactive_companion(value, now: datetime | None = None) -> dict:
 def clamp_repeat_count(value) -> int:
     try:
         count = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         count = 1
     return max(1, min(24, count))
 

--- a/tests/test_reminder_numeric_safety.py
+++ b/tests/test_reminder_numeric_safety.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+import unittest
+
+from reminder_core import normalize_pomodoro, normalize_proactive_item
+
+
+class ReminderNumericSafetyTest(unittest.TestCase):
+    def test_interval_reminder_tolerates_infinite_minutes(self):
+        item = normalize_proactive_item(
+            {
+                "id": "custom-interval",
+                "schedule_type": "interval",
+                "interval_minutes": float("inf"),
+            },
+            now=datetime(2026, 7, 16, 9, 0, 0),
+        )
+
+        self.assertEqual(60, item["interval_minutes"])
+
+    def test_pomodoro_tolerates_infinite_counts_and_duration(self):
+        item = normalize_pomodoro(
+            {
+                "id": "pomodoro-test",
+                "repeat_count": float("inf"),
+                "completed_focus_count": float("inf"),
+                "phase_duration_sec": float("inf"),
+            },
+            now=datetime(2026, 7, 16, 9, 0, 0),
+        )
+
+        self.assertEqual(1, item["repeat_count"])
+        self.assertEqual(0, item["completed_focus_count"])
+        self.assertGreater(item["phase_duration_sec"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容
- 主动提醒间隔在整数溢出时回退模板默认值。
- 番茄钟循环次数、完成次数和阶段时长在溢出时安全回退。
- 增加间隔提醒及番茄钟持久化 Infinity 数据回归测试。

## 根因与影响
提醒数据的三个共享整数规范化函数仅捕获类型和格式错误。持久化数据包含 Infinity 时会在调度器加载阶段抛出 `OverflowError`，阻止提醒、番茄钟和主动陪伴功能运行。

## 验证
- `python3 -m pytest -q tests/test_reminder_numeric_safety.py tests/test_reminder_scheduler.py tests/test_local_reminder_tool_save_semantics.py`
- 结果：19 passed
- `python3 -m pytest -q tests`
- 结果：489 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile reminder_core.py tests/test_reminder_numeric_safety.py`
- `git diff --check`
