### PR TITLE
规范 ASR 数值配置

### DIFF
--- a/asr_manager.py
+++ b/asr_manager.py
@@ -1,4 +1,5 @@
 import io
+import math
 import ntpath
 import os
 import shutil
@@ -12,7 +13,7 @@ from pathlib import Path
 
 from PySide6.QtCore import QThread, Signal
 
-from process_utils import app_base_dir, app_runtime_dir
+from process_utils import app_base_dir, app_runtime_dir, clamp_int
 
 
 _NUMPY_MODULE = None
@@ -26,6 +27,20 @@ ASR_LOCAL_DEVICE = "cpu"
 ASR_LOCAL_COMPUTE_TYPE = "int8"
 _LOCAL_ASR_PROCESS = None
 _LOCAL_ASR_LOCK = threading.Lock()
+
+
+def _asr_sample_rate(value) -> int:
+    return clamp_int(value, 8000, 192000, 16000)
+
+
+def _bounded_float(value, *, default: float, minimum: float, maximum: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        number = default
+    if not math.isfinite(number):
+        number = default
+    return max(minimum, min(maximum, number))
 
 
 class ASRInstallCancelled(RuntimeError):
@@ -641,8 +656,13 @@ class ASRRecorderWorker(QThread):
         self._config = dict(config or {})
 
     def run(self):
-        sample_rate = int(self._config.get("asr_sample_rate", 16000) or 16000)
-        max_seconds = max(1.0, float(self._config.get("asr_max_record_seconds", 60) or 60))
+        sample_rate = _asr_sample_rate(self._config.get("asr_sample_rate", 16000))
+        max_seconds = _bounded_float(
+            self._config.get("asr_max_record_seconds", 60),
+            default=60.0,
+            minimum=1.0,
+            maximum=300.0,
+        )
         channels = 1
         chunks = []
         started = time.monotonic()
@@ -750,7 +770,12 @@ class ASRRequestWorker(_CancelableASRWorker):
         api_key = str(self._config.get("asr_api_key", "") or "").strip()
         model = str(self._config.get("asr_model_id", "") or "").strip() or "whisper-large-v3"
         language = str(self._config.get("asr_language", "") or "").strip()
-        timeout = max(5.0, float(self._config.get("asr_timeout_seconds", 60) or 60))
+        timeout = _bounded_float(
+            self._config.get("asr_timeout_seconds", 60),
+            default=60.0,
+            minimum=5.0,
+            maximum=600.0,
+        )
         headers = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"

--- a/tests/test_asr_python_detection.py
+++ b/tests/test_asr_python_detection.py
@@ -5,6 +5,27 @@ import asr_manager
 
 
 class ASRPythonDetectionTest(unittest.TestCase):
+    def test_numeric_config_tolerates_infinite_values(self):
+        self.assertEqual(16000, asr_manager._asr_sample_rate(float("inf")))
+        self.assertEqual(
+            60.0,
+            asr_manager._bounded_float(
+                float("inf"),
+                default=60.0,
+                minimum=1.0,
+                maximum=300.0,
+            ),
+        )
+        self.assertEqual(
+            600.0,
+            asr_manager._bounded_float(
+                9999,
+                default=60.0,
+                minimum=5.0,
+                maximum=600.0,
+            ),
+        )
+
     def test_windows_store_alias_is_rejected(self):
         alias = r"C:\Users\demo\AppData\Local\Microsoft\WindowsApps\python.exe"
         with (


### PR DESCRIPTION
## 修复内容
- ASR 采样率限制为 8,000–192,000 Hz，异常值回退 16,000 Hz。
- 最长录音限制为 1–300 秒，非有限值回退 60 秒。
- ASR 请求超时限制为 5–600 秒，非有限值回退 60 秒。
- 增加 Infinity 回退及有限极值裁剪测试。

## 根因与影响
录音 worker 和请求 worker 直接转换配置。采样率 Infinity 会抛 `OverflowError`，最长录音 Infinity 会使录音永不自动结束，请求超时 Infinity 也会传入无效网络参数。

## 验证
- `python3 -m pytest -q tests/test_asr_python_detection.py tests/test_audio_runtime_safety.py`
- 结果：12 passed
- `python3 -m pytest -q tests`
- 结果：490 passed, 1 skipped, 74 subtests passed
- `python3 -m py_compile asr_manager.py tests/test_asr_python_detection.py`
- `git diff --check`
