### PR TITLE
修复 ASR 设置页数值溢出

### DIFF
--- a/settings_window/pages/asr.py
+++ b/settings_window/pages/asr.py
@@ -1,6 +1,7 @@
 from settings_window.constants import *
 from settings_window.widgets import *
 from settings_window.workers import *
+from process_utils import clamp_int
 
 
 class ASRPageMixin:
@@ -204,7 +205,13 @@ class ASRPageMixin:
                     self._asr_insert_mode.setCurrentIndex(i)
                     break
             self._asr_auto_send.setChecked(bool(self._cfg.get("asr_auto_send", False)))
-            self._asr_max_record_seconds.setValue(int(self._cfg.get("asr_max_record_seconds", 60) or 60))
+            max_record_seconds = clamp_int(
+                self._cfg.get("asr_max_record_seconds", 60) or 60,
+                3,
+                300,
+                60,
+            )
+            self._asr_max_record_seconds.setValue(max_record_seconds)
 
     def _current_asr_config(self) -> dict:
         max_record_seconds = int(self._asr_max_record_seconds.value())

--- a/tests/test_asr_settings_numeric.py
+++ b/tests/test_asr_settings_numeric.py
@@ -1,0 +1,61 @@
+import unittest
+
+from settings_window.pages.asr import ASRPageMixin
+
+
+class _ValueWidget:
+    def __init__(self):
+        self.value = None
+
+    def setChecked(self, value):
+        self.value = value
+
+    def setText(self, value):
+        self.value = value
+
+    def setValue(self, value):
+        self.value = value
+
+
+class _ChoiceWidget:
+    def __init__(self, values):
+        self._values = values
+        self.value = None
+
+    def count(self):
+        return len(self._values)
+
+    def itemData(self, index):
+        return self._values[index]
+
+    def setCurrentIndex(self, index):
+        self.value = index
+
+
+class _ASRSettingsHarness(ASRPageMixin):
+    def __init__(self, max_record_seconds):
+        self._cfg = {"asr_max_record_seconds": max_record_seconds}
+        self._asr_enabled = _ValueWidget()
+        self._asr_api_url = _ValueWidget()
+        self._asr_api_key = _ValueWidget()
+        self._asr_model_id = _ValueWidget()
+        self._asr_language = _ChoiceWidget(["", "zh", "ja", "en"])
+        self._asr_insert_mode = _ChoiceWidget(["append", "replace"])
+        self._asr_auto_send = _ValueWidget()
+        self._asr_max_record_seconds = _ValueWidget()
+
+    def _asr_config_widgets_ready(self):
+        return True
+
+
+class ASRSettingsNumericTest(unittest.TestCase):
+    def test_load_config_tolerates_infinite_record_duration(self):
+        page = _ASRSettingsHarness(float("inf"))
+
+        page._load_asr_config()
+
+        self.assertEqual(60, page._asr_max_record_seconds.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

ASR 运行时已经能够处理损坏的数值配置，但设置页加载 `asr_max_record_seconds` 时仍直接调用 `int(...)`。当配置值为 `Infinity` 等非有限数值时，打开设置窗口会抛出 `OverflowError`。

## 修复

- 复用 `clamp_int` 规范化最长录音时长
- 将有效范围限制为控件支持的 3–300 秒
- 无法解析或非有限的值回退为 60 秒
- 添加覆盖真实设置加载路径的回归测试

## 验证

- `python3 -m pytest -q tests/test_asr_settings_numeric.py tests/test_asr_python_detection.py`
- `python3 -m py_compile settings_window/pages/asr.py tests/test_asr_settings_numeric.py`
- `git diff --check`
- `python3 -m pytest -q tests`（491 passed, 1 skipped, 74 subtests passed）
