### PR TITLE
修复屏幕感知设置数值溢出

### DIFF
--- a/settings_window/pages/screen_awareness.py
+++ b/settings_window/pages/screen_awareness.py
@@ -1,6 +1,10 @@
 from settings_window.constants import *
 from settings_window.widgets import *
 from settings_window.workers import *
+from screen_awareness import (
+    clamp_screen_awareness_interval,
+    clamp_screen_awareness_screenshot_width,
+)
 
 
 SCREEN_AWARENESS_CONFIG_KEYS = (
@@ -187,9 +191,8 @@ class ScreenAwarenessPageMixin:
             policy = normalize_proactive_care_policy(
                 self._cfg.get(PROACTIVE_CARE_POLICY_CONFIG_KEY, {})
             )
-            policy["global_cooldown_minutes"] = max(
-                5,
-                min(120, int(data.get("screen_awareness_interval_minutes", 30) or 30)),
+            policy["global_cooldown_minutes"] = clamp_screen_awareness_interval(
+                data.get("screen_awareness_interval_minutes", 30) or 30
             )
             self._cfg.set(PROACTIVE_CARE_POLICY_CONFIG_KEY, policy)
         self._load_screen_awareness_controls()
@@ -245,16 +248,20 @@ class ScreenAwarenessPageMixin:
             return
         self._screen_awareness_enabled.setChecked(bool(self._cfg.get("screen_awareness_enabled", False)))
         policy = normalize_proactive_care_policy(self._cfg.get(PROACTIVE_CARE_POLICY_CONFIG_KEY, {}))
-        shared_interval = int(policy.get(
+        shared_interval = clamp_screen_awareness_interval(policy.get(
             "global_cooldown_minutes",
             self._cfg.get("screen_awareness_interval_minutes", 30),
         ) or 30)
-        self._screen_awareness_interval.setValue(max(5, min(120, shared_interval)))
+        self._screen_awareness_interval.setValue(shared_interval)
         self._fill_screen_awareness_character_combo(
             str(self._cfg.get("screen_awareness_character_mode", "random_visible") or "random_visible"),
             self._cfg.get("screen_awareness_character", ""),
         )
-        self._screen_awareness_max_width.setValue(max(640, min(1920, int(self._cfg.get("screen_awareness_max_screenshot_width", 1920) or 1920))))
+        self._screen_awareness_max_width.setValue(
+            clamp_screen_awareness_screenshot_width(
+                self._cfg.get("screen_awareness_max_screenshot_width", 1920) or 1920
+            )
+        )
         self._set_screen_awareness_model_mode(self._cfg.get("screen_awareness_model_mode", "main"))
         self._set_screen_awareness_display_mode(
             self._cfg.get(SCREEN_AWARENESS_DISPLAY_MODE_KEY, DISPLAY_MODE_FLOATING)
@@ -298,10 +305,14 @@ class ScreenAwarenessPageMixin:
         if self._cfg:
             return {
                 "screen_awareness_enabled": bool(self._cfg.get("screen_awareness_enabled", False)),
-                "screen_awareness_interval_minutes": int(self._cfg.get("screen_awareness_interval_minutes", 30) or 30),
+                "screen_awareness_interval_minutes": clamp_screen_awareness_interval(
+                    self._cfg.get("screen_awareness_interval_minutes", 30) or 30
+                ),
                 "screen_awareness_character_mode": str(self._cfg.get("screen_awareness_character_mode", "random_visible") or "random_visible"),
                 "screen_awareness_character": str(self._cfg.get("screen_awareness_character", "") or ""),
-                "screen_awareness_max_screenshot_width": int(self._cfg.get("screen_awareness_max_screenshot_width", 1920) or 1920),
+                "screen_awareness_max_screenshot_width": clamp_screen_awareness_screenshot_width(
+                    self._cfg.get("screen_awareness_max_screenshot_width", 1920) or 1920
+                ),
                 "screen_awareness_model_mode": str(self._cfg.get("screen_awareness_model_mode", "main") or "main"),
                 "screen_awareness_include_process_name": bool(self._cfg.get("screen_awareness_include_process_name", True)),
                 "screen_awareness_include_window_title": bool(self._cfg.get("screen_awareness_include_window_title", False)),

--- a/tests/test_screen_awareness_settings_numeric.py
+++ b/tests/test_screen_awareness_settings_numeric.py
@@ -1,0 +1,75 @@
+import unittest
+
+from reminder_core import PROACTIVE_CARE_POLICY_CONFIG_KEY
+from settings_window.pages.screen_awareness import ScreenAwarenessPageMixin
+
+
+class _Config(dict):
+    def set(self, key, value):
+        self[key] = value
+
+
+class _ValueWidget:
+    def __init__(self):
+        self.value = None
+
+    def setChecked(self, value):
+        self.value = value
+
+    def setValue(self, value):
+        self.value = value
+
+
+class _ScreenAwarenessHarness(ScreenAwarenessPageMixin):
+    def __init__(self, config):
+        self._cfg = _Config(config)
+        self._screen_awareness_enabled = _ValueWidget()
+        self._screen_awareness_interval = _ValueWidget()
+        self._screen_awareness_max_width = _ValueWidget()
+
+    def _fill_screen_awareness_character_combo(self, mode="random_visible", selected=""):
+        pass
+
+    def _set_screen_awareness_model_mode(self, mode):
+        pass
+
+    def _set_screen_awareness_display_mode(self, mode):
+        pass
+
+
+class ScreenAwarenessSettingsNumericTest(unittest.TestCase):
+    def test_load_controls_tolerates_infinite_screenshot_width(self):
+        page = _ScreenAwarenessHarness(
+            {"screen_awareness_max_screenshot_width": float("inf")}
+        )
+
+        page._load_screen_awareness_controls()
+
+        self.assertEqual(1920, page._screen_awareness_max_width.value)
+
+    def test_settings_data_tolerates_infinite_numeric_values(self):
+        page = _ScreenAwarenessHarness(
+            {
+                "screen_awareness_interval_minutes": float("inf"),
+                "screen_awareness_max_screenshot_width": float("inf"),
+            }
+        )
+
+        data = page._screen_awareness_settings_data()
+
+        self.assertEqual(30, data["screen_awareness_interval_minutes"])
+        self.assertEqual(1920, data["screen_awareness_max_screenshot_width"])
+
+    def test_remote_interval_tolerates_infinite_value(self):
+        page = _ScreenAwarenessHarness({"screen_awareness_enabled": False})
+
+        page._apply_screen_awareness_remote_settings(
+            {"screen_awareness_interval_minutes": float("inf")}
+        )
+
+        policy = page._cfg[PROACTIVE_CARE_POLICY_CONFIG_KEY]
+        self.assertEqual(30, policy["global_cooldown_minutes"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

屏幕感知运行线程已经会规范化数值配置，但设置页的控件加载、远程设置应用和设置数据导出仍直接调用 `int(...)`。当同步或本地配置含 `Infinity` 等非有限值时，这些入口会抛出 `OverflowError`。

## 修复

- 设置页统一复用屏幕感知模块的间隔与截图宽度规范化函数
- 间隔限制为 5–120 分钟，异常值回退为 30 分钟
- 截图宽度限制为 640–1920，异常值回退为 1920
- 为控件加载、远程设置和数据导出三个入口添加回归测试

## 验证

- `python3 -m pytest -q tests/test_screen_awareness_settings_numeric.py tests/test_screen_awareness.py tests/test_settings_screen_awareness_layout.py`
- `python3 -m py_compile settings_window/pages/screen_awareness.py tests/test_screen_awareness_settings_numeric.py`
- `git diff --check`
- `python3 -m pytest -q tests`（494 passed, 1 skipped, 74 subtests passed）
