### PR TITLE
修复 LLM 配置档案数值溢出

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -484,7 +484,7 @@ def normalize_model_action_profile(profile) -> dict:
 def _int_value(value, default: int) -> int:
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
 
 

--- a/tests/test_config_load_safety.py
+++ b/tests/test_config_load_safety.py
@@ -8,6 +8,24 @@ from config_manager import DEFAULTS, ConfigManager
 
 
 class ConfigLoadSafetyTests(unittest.TestCase):
+    def test_load_tolerates_overflowing_llm_profile_numbers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "config.json"
+            path.write_text(
+                '{"llm_api_profiles":[{"name":"custom",'
+                '"llm_auto_continue_max_turns":1e309}]}',
+                encoding="utf-8",
+            )
+
+            config = ConfigManager(path)
+
+            profile = next(
+                item
+                for item in config.get("llm_api_profiles")
+                if item["name"] == "custom"
+            )
+            self.assertEqual(5, profile["llm_auto_continue_max_turns"])
+
     def test_transient_read_error_does_not_move_valid_config(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "config.json"


### PR DESCRIPTION
## 问题

应用启动时会规范化已保存的 LLM API 配置档案。通用整数解析器只处理类型和格式错误，未处理数值溢出；配置文件中的合法 JSON 数字 `1e309` 会解析成无穷值，并在 `int(...)` 时抛出 `OverflowError`，导致配置管理器初始化失败。

## 修复

- 将 `OverflowError` 纳入配置整数解析的默认值回退逻辑
- 添加从磁盘读取真实 JSON 配置并完成档案规范化的启动级回归测试

## 验证

- `python3 -m pytest -q tests/test_config_load_safety.py tests/test_chat_context_limits.py`
- `python3 -m py_compile config_manager.py tests/test_config_load_safety.py`
- `git diff --check`
- `python3 -m pytest -q tests`（495 passed, 1 skipped, 74 subtests passed）
