### PR TITLE
修复 LLM 设置页数值溢出

### DIFF
--- a/settings_window/pages/llm.py
+++ b/settings_window/pages/llm.py
@@ -1,6 +1,7 @@
 from settings_window.constants import *
 from settings_window.widgets import *
 from settings_window.workers import *
+from process_utils import clamp_int
 from token_usage import (
     HISTORY_MESSAGE_LIMIT_SLIDER_MAX,
     history_message_limit_from_slider,
@@ -35,6 +36,10 @@ LLM_API_PROFILE_KEYS = (
 
 
 class LLMPageMixin:
+
+    @staticmethod
+    def _auto_continue_max_turns(value) -> int:
+        return clamp_int(value or 5, 1, 20, 5)
 
     @staticmethod
     def _history_message_limit(value, default: int) -> int:
@@ -744,11 +749,11 @@ class LLMPageMixin:
             self._llm_web_search_show_sources.setChecked(bool(self._cfg.get("llm_web_search_show_sources", True)))
             self._llm_web_fetch_enabled.setChecked(bool(self._cfg.get("llm_web_fetch_enabled", False)))
             self._llm_auto_continue_enabled.setChecked(bool(self._cfg.get("llm_auto_continue_enabled", False)))
-            try:
-                auto_continue_max = int(self._cfg.get("llm_auto_continue_max_turns", 5) or 5)
-            except (TypeError, ValueError):
-                auto_continue_max = 5
-            self._llm_auto_continue_max_turns.setValue(max(1, min(20, auto_continue_max)))
+            self._llm_auto_continue_max_turns.setValue(
+                self._auto_continue_max_turns(
+                    self._cfg.get("llm_auto_continue_max_turns", 5)
+                )
+            )
             self._llm_chat_history_message_limit.setValue(
                 self._history_message_limit_slider_value(
                     self._cfg.get("llm_chat_history_message_limit", 40),
@@ -843,8 +848,9 @@ class LLMPageMixin:
                 "llm_web_search_show_sources": bool(profile.get("llm_web_search_show_sources", True)),
                 "llm_web_fetch_enabled": bool(profile.get("llm_web_fetch_enabled", False)),
                 "llm_auto_continue_enabled": bool(profile.get("llm_auto_continue_enabled", False)),
-                "llm_auto_continue_max_turns": max(1, min(20, int(profile.get("llm_auto_continue_max_turns", 5) or 5)))
-                if str(profile.get("llm_auto_continue_max_turns", 5) or "").strip().lstrip("-").isdigit() else 5,
+                "llm_auto_continue_max_turns": self._auto_continue_max_turns(
+                    profile.get("llm_auto_continue_max_turns", 5)
+                ),
                 "llm_chat_history_message_limit": self._history_message_limit(
                     profile.get("llm_chat_history_message_limit", 40),
                     40,
@@ -915,8 +921,9 @@ class LLMPageMixin:
             "llm_web_search_show_sources": bool(self._cfg.get("llm_web_search_show_sources", True)),
             "llm_web_fetch_enabled": bool(self._cfg.get("llm_web_fetch_enabled", False)),
             "llm_auto_continue_enabled": bool(self._cfg.get("llm_auto_continue_enabled", False)),
-            "llm_auto_continue_max_turns": max(1, min(20, int(self._cfg.get("llm_auto_continue_max_turns", 5) or 5)))
-            if str(self._cfg.get("llm_auto_continue_max_turns", 5) or "").strip().lstrip("-").isdigit() else 5,
+            "llm_auto_continue_max_turns": self._auto_continue_max_turns(
+                self._cfg.get("llm_auto_continue_max_turns", 5)
+            ),
             "llm_chat_history_message_limit": self._history_message_limit(
                 self._cfg.get("llm_chat_history_message_limit", 40),
                 40,
@@ -1069,11 +1076,11 @@ class LLMPageMixin:
         self._llm_web_search_show_sources.setChecked(bool(profile.get("llm_web_search_show_sources", True)))
         self._llm_web_fetch_enabled.setChecked(bool(profile.get("llm_web_fetch_enabled", False)))
         self._llm_auto_continue_enabled.setChecked(bool(profile.get("llm_auto_continue_enabled", False)))
-        try:
-            auto_continue_max = int(profile.get("llm_auto_continue_max_turns", 5) or 5)
-        except (TypeError, ValueError):
-            auto_continue_max = 5
-        self._llm_auto_continue_max_turns.setValue(max(1, min(20, auto_continue_max)))
+        self._llm_auto_continue_max_turns.setValue(
+            self._auto_continue_max_turns(
+                profile.get("llm_auto_continue_max_turns", 5)
+            )
+        )
         self._llm_chat_history_message_limit.setValue(
             self._history_message_limit_slider_value(
                 profile.get("llm_chat_history_message_limit", 40),

--- a/tests/test_llm_api_profile_save.py
+++ b/tests/test_llm_api_profile_save.py
@@ -208,6 +208,41 @@ class LLMApiProfileSaveTests(unittest.TestCase):
         page.close()
         harness.close()
 
+    def test_load_config_tolerates_infinite_auto_continue_limit(self):
+        harness = _LLMPageHarness()
+        page = harness._build_llm_page()
+        harness._cfg = _ConfigStub()
+        harness._cfg.data["llm_auto_continue_max_turns"] = float("inf")
+        harness._cfg.data["llm_active_api_profile"] = "test"
+        harness._cfg.active_user_profile = lambda: {"key": "test"}
+        harness._llm_config_widgets_ready = lambda: True
+        harness._reload_user_profile_combo = lambda _key: None
+        harness._load_user_profile_fields = lambda _profile: None
+        harness._pov_mode = harness._llm_api_mode
+        harness._pov_custom_prompt = harness._llm_custom_system_prompt
+        harness._pov_role_character = harness._llm_api_mode
+        harness._reload_pov_persona_combo = lambda: None
+        harness._on_pov_mode_changed = lambda _index: None
+        harness._reload_llm_api_profiles = lambda _name: None
+
+        harness._load_llm_config()
+
+        self.assertEqual(5, harness._llm_auto_continue_max_turns.value())
+        page.close()
+        harness.close()
+
+    def test_apply_profile_tolerates_infinite_auto_continue_limit(self):
+        harness = _LLMPageHarness()
+        page = harness._build_llm_page()
+
+        harness._apply_llm_api_profile(
+            _profile(llm_auto_continue_max_turns=float("inf"))
+        )
+
+        self.assertEqual(5, harness._llm_auto_continue_max_turns.value())
+        page.close()
+        harness.close()
+
     def test_live_widget_values_are_compared_with_active_profile(self):
         profile = _profile(llm_model_id="saved-model")
         harness = _LLMProfileHarness(profile)


### PR DESCRIPTION
## 问题

顶层 LLM 自动续写回合数不会经过 API 档案规范化。设置页加载顶层配置或直接应用档案时仍调用 `int(...)`，且只捕获类型和格式错误；`Infinity` 等非有限值会抛出 `OverflowError`，导致页面加载或档案切换失败。

## 修复

- 为设置页增加统一的自动续写回合数规范化入口
- 将值限制为 1–20，异常值回退为 5
- 让配置加载、档案应用、档案列表规范化和当前配置快照使用同一逻辑
- 添加覆盖真实 Qt 设置加载与档案切换路径的回归测试

## 验证

- `python3 -m pytest -q tests/test_llm_api_profile_save.py tests/test_chat_context_limits.py tests/test_worker_helper_deduplication.py`
- `python3 -m py_compile settings_window/pages/llm.py tests/test_llm_api_profile_save.py`
- `git diff --check`
- `python3 -m pytest -q tests`（497 passed, 1 skipped, 74 subtests passed）
