### PR TITLE
修复数据库统计数值溢出

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -76,7 +76,7 @@ def _db_text(value, default: str = "") -> str:
 def _db_int(value) -> int | None:
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
 
 

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -149,6 +149,31 @@ class TokenUsageTests(unittest.TestCase):
         self.assertEqual(usage["untracked_count"], 1)
         self.assertTrue(usage["estimated"])
 
+    def test_database_usage_tolerates_overflowing_provider_counts(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db = DatabaseManager(os.path.join(temp_dir, "usage.db"))
+            conversation_id = db.create_conversation("test")
+            db.add_message(
+                conversation_id,
+                "assistant",
+                "overflow",
+                tool_trace={
+                    "llm_usage": {
+                        "input_tokens": float("inf"),
+                        "output_tokens": 25,
+                        "total_tokens": float("inf"),
+                    }
+                },
+            )
+
+            usage = db.get_conversation_token_usage(conversation_id)
+            db.close()
+
+        self.assertEqual(0, usage["input_tokens"])
+        self.assertEqual(25, usage["output_tokens"])
+        self.assertEqual(25, usage["total_tokens"])
+        self.assertEqual(1, usage["request_count"])
+
     def test_tokens_command_uses_resolver(self):
         result = handle_command(
             object(),


### PR DESCRIPTION
## 问题

历史消息的 `tool_trace_json` 会保存模型供应商返回的 token 用量。超大 JSON 数字或已保存的非有限计数会在读取时成为无穷值，数据库聚合调用 `int(...)` 后抛出 `OverflowError`，导致会话 token 统计和相关命令失败。

## 修复

- 数据库通用整数读取器将数值溢出视为不可用字段
- token 聚合继续保留同一记录中的其他有效计数，并按现有逻辑推导总计
- 添加经过真实临时 SQLite 写入与读取路径的回归测试

## 验证

- `python3 -m pytest -q tests/test_token_usage.py tests/test_database_memory_safety.py`
- `python3 -m py_compile database_manager.py tests/test_token_usage.py`
- `git diff --check`
- `python3 -m pytest -q tests`（498 passed, 1 skipped, 74 subtests passed）
