### PR TITLE
修复使用时长统计数值溢出

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -2181,7 +2181,7 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             "SELECT COALESCE(SUM(duration_seconds),0) FROM usage_sessions "
             "WHERE date(start_time)=date('now','localtime')"
         ).fetchone()
-        total = int(row[0]) if row else 0
+        total = (_db_int(row[0]) or 0) if row else 0
         cur = self._conn.execute(
             "SELECT id, COALESCE(duration_seconds,0) FROM usage_sessions "
             "WHERE end_time IS NULL AND date(start_time)=date('now','localtime') "
@@ -2192,8 +2192,8 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
                 "SELECT CAST((julianday('now','localtime')-julianday(start_time))*86400 AS INTEGER) "
                 "FROM usage_sessions WHERE id=?", (int(cur[0]),)
             ).fetchone()
-            live = int(live_row[0]) if live_row and live_row[0] is not None else 0
-            total = total - int(cur[1]) + live
+            live = (_db_int(live_row[0]) or 0) if live_row else 0
+            total = total - (_db_int(cur[1]) or 0) + live
         return total
 
     def get_usage_week(self) -> int:
@@ -2201,7 +2201,7 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             "SELECT COALESCE(SUM(duration_seconds),0) FROM usage_sessions "
             "WHERE start_time>=datetime('now','localtime','-6 days','start of day')"
         ).fetchone()
-        total = int(row[0]) if row else 0
+        total = (_db_int(row[0]) or 0) if row else 0
         cur = self._conn.execute(
             "SELECT id, COALESCE(duration_seconds,0) FROM usage_sessions "
             "WHERE end_time IS NULL AND start_time>=datetime('now','localtime','-6 days','start of day') "
@@ -2212,15 +2212,15 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
                 "SELECT CAST((julianday('now','localtime')-julianday(start_time))*86400 AS INTEGER) "
                 "FROM usage_sessions WHERE id=?", (int(cur[0]),)
             ).fetchone()
-            live = int(live_row[0]) if live_row and live_row[0] is not None else 0
-            total = total - int(cur[1]) + live
+            live = (_db_int(live_row[0]) or 0) if live_row else 0
+            total = total - (_db_int(cur[1]) or 0) + live
         return total
 
     def get_usage_all_time(self) -> int:
         row = self._conn.execute(
             "SELECT COALESCE(SUM(duration_seconds),0) FROM usage_sessions"
         ).fetchone()
-        total = int(row[0]) if row else 0
+        total = (_db_int(row[0]) or 0) if row else 0
         cur = self._conn.execute(
             "SELECT id, COALESCE(duration_seconds,0) FROM usage_sessions "
             "WHERE end_time IS NULL ORDER BY id DESC LIMIT 1"
@@ -2230,8 +2230,8 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
                 "SELECT CAST((julianday('now','localtime')-julianday(start_time))*86400 AS INTEGER) "
                 "FROM usage_sessions WHERE id=?", (int(cur[0]),)
             ).fetchone()
-            live = int(live_row[0]) if live_row and live_row[0] is not None else 0
-            total = total - int(cur[1]) + live
+            live = (_db_int(live_row[0]) or 0) if live_row else 0
+            total = total - (_db_int(cur[1]) or 0) + live
         return total
 
     def get_usage_daily(self, days: int = 30) -> list[dict]:
@@ -2242,7 +2242,7 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             "GROUP BY date(start_time) ORDER BY day ASC",
             (f"-{days} days",),
         ).fetchall()
-        return [{"day": r[0], "seconds": int(r[1])} for r in rows]
+        return [{"day": r[0], "seconds": _db_int(r[1]) or 0} for r in rows]
 
     # ── Statistics queries ──────────────────────────────────────────────
 

--- a/tests/test_database_memory_safety.py
+++ b/tests/test_database_memory_safety.py
@@ -12,6 +12,31 @@ from database_manager import DatabaseManager
 
 
 class DatabaseMemorySafetyTests(unittest.TestCase):
+    def test_usage_statistics_tolerate_overflowing_session_duration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db = DatabaseManager(str(Path(temp_dir) / "data.db"))
+            try:
+                db._conn.execute(
+                    "INSERT INTO usage_sessions "
+                    "(start_time, end_time, duration_seconds) "
+                    "VALUES (datetime('now','localtime'), "
+                    "datetime('now','localtime'), ?)",
+                    (float("inf"),),
+                )
+                db._conn.commit()
+
+                today = db.get_usage_today()
+                week = db.get_usage_week()
+                all_time = db.get_usage_all_time()
+                daily = db.get_usage_daily()
+            finally:
+                db.close()
+
+        self.assertEqual(0, today)
+        self.assertEqual(0, week)
+        self.assertEqual(0, all_time)
+        self.assertEqual(0, daily[-1]["seconds"])
+
     def test_relationship_zero_values_are_not_replaced_by_defaults(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             db = DatabaseManager(str(Path(temp_dir) / "data.db"))


### PR DESCRIPTION
## 问题

SQLite 使用动态类型，损坏或迁移后的 `usage_sessions.duration_seconds` 可以包含非有限实数。今日、本周、累计及每日图表查询都直接将 `SUM()` 结果转换为整数，遇到无穷值时会抛出 `OverflowError`，导致统计页面读取失败。

## 修复

- 四个使用时长统计入口统一使用安全的数据库整数读取器
- 聚合值、活动会话旧值和实时值无法转换时按 0 处理
- 添加真实 SQLite 溢出行回归测试，覆盖今日、本周、累计与每日统计

## 验证

- `python3 -m pytest -q tests/test_database_memory_safety.py tests/test_token_usage.py`
- `python3 -m py_compile database_manager.py tests/test_database_memory_safety.py`
- `git diff --check`
- `python3 -m pytest -q tests`（499 passed, 1 skipped, 74 subtests passed）
